### PR TITLE
CLN: Make genericity of types more specific.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,0 @@
-- MortonKeys has to have a phantom field for carrying the precison
-    - Should always be using morton constructors...
-- Need to figure out which parts need real numbers only, and which parts can be generic over any scalar
-- Need to implement Helmholtz FMM
-    - The only bit that might break is the
-        - Pinv part
-    - The P2P part may be significantly slower, especially for gradients.
-    - As might the other operators, M2M and L2L, as these are now both zgemm operations.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,8 @@
+- MortonKeys has to have a phantom field for carrying the precison
+    - Should always be using morton constructors...
+- Need to figure out which parts need real numbers only, and which parts can be generic over any scalar
+- Need to implement Helmholtz FMM
+    - The only bit that might break is the
+        - Pinv part
+    - The P2P part may be significantly slower, especially for gradients.
+    - As might the other operators, M2M and L2L, as these are now both zgemm operations.

--- a/kifmm/examples/mpi_test_multi_node_tree.rs
+++ b/kifmm/examples/mpi_test_multi_node_tree.rs
@@ -57,13 +57,13 @@ fn test_no_overlaps<T: RlstScalarFloatMpi<Real = T>>(
 
 /// Test that the globally defined domain contains all the points at a given node.
 #[cfg(feature = "mpi")]
-fn test_global_bounds<T: RlstScalarFloatMpi + SampleUniform>(world: &UserCommunicator) {
+fn test_global_bounds<T: RlstScalarFloatMpi<Real = T> + SampleUniform>(world: &UserCommunicator) {
     let n_points = 10000;
     let points = points_fixture::<T>(n_points, None, None, None);
 
     let comm = world.duplicate();
 
-    let domain = Domain::from_global_points(points.data(), &comm);
+    let domain = Domain::<T>::from_global_points(points.data(), &comm);
 
     // Test that all local points are contained within the global domain
     for i in 0..n_points {

--- a/kifmm/examples/mpi_test_multi_node_tree.rs
+++ b/kifmm/examples/mpi_test_multi_node_tree.rs
@@ -57,9 +57,7 @@ fn test_no_overlaps<T: RlstScalarFloatMpi<Real = T>>(
 
 /// Test that the globally defined domain contains all the points at a given node.
 #[cfg(feature = "mpi")]
-fn test_global_bounds<T: RlstScalarFloatMpi + SampleUniform>(
-    world: &UserCommunicator,
-) {
+fn test_global_bounds<T: RlstScalarFloatMpi + SampleUniform>(world: &UserCommunicator) {
     let n_points = 10000;
     let points = points_fixture::<T>(n_points, None, None, None);
 

--- a/kifmm/examples/mpi_test_multi_node_tree.rs
+++ b/kifmm/examples/mpi_test_multi_node_tree.rs
@@ -5,21 +5,26 @@ use rand::distributions::uniform::SampleUniform;
 
 use rlst::{RawAccess, RlstScalar};
 
-use kifmm::{traits::tree::Tree, tree::helpers::points_fixture};
+use kifmm::{traits::tree::Tree, tree::helpers::points_fixture, RlstScalarFloat};
 
 #[cfg(feature = "mpi")]
 use mpi::{environment::Universe, topology::UserCommunicator, traits::*};
+
+#[cfg(feature = "mpi")]
+use kifmm::RlstScalarFloatMpi;
 
 #[cfg(feature = "mpi")]
 use kifmm::tree::types::{Domain, MortonKey, MultiNodeTree};
 
 /// Test that the leaves on separate nodes do not overlap.
 #[cfg(feature = "mpi")]
-fn test_no_overlaps<T: Float + Default + RlstScalar<Real = T>>(
+fn test_no_overlaps<T: RlstScalarFloatMpi<Real = T>>(
     world: &UserCommunicator,
     tree: &MultiNodeTree<T>,
 ) {
     // Communicate bounds from each process
+
+    use kifmm::RlstScalarFloat;
     let max = tree.all_leaves_set().unwrap().iter().max().unwrap();
     let min = tree.all_leaves_set().unwrap().iter().min().unwrap();
 
@@ -52,7 +57,7 @@ fn test_no_overlaps<T: Float + Default + RlstScalar<Real = T>>(
 
 /// Test that the globally defined domain contains all the points at a given node.
 #[cfg(feature = "mpi")]
-fn test_global_bounds<T: RlstScalar + Float + Default + Equivalence + SampleUniform>(
+fn test_global_bounds<T: RlstScalarFloatMpi + SampleUniform>(
     world: &UserCommunicator,
 ) {
     let n_points = 10000;
@@ -76,10 +81,12 @@ fn test_global_bounds<T: RlstScalar + Float + Default + Equivalence + SampleUnif
 
 /// Test that all leaves are mapped
 #[cfg(feature = "mpi")]
-fn test_n_leaves<T: RlstScalar<Real = T> + Float + Default + Equivalence + SampleUniform>(
+fn test_n_leaves<T: RlstScalarFloatMpi<Real = T> + SampleUniform>(
     world: &UserCommunicator,
     tree: &MultiNodeTree<T>,
 ) {
+    use kifmm::RlstScalarFloatMpi;
+
     let n_leaves = tree.n_leaves().unwrap();
 
     let size = world.size() as usize;
@@ -97,7 +104,7 @@ fn test_n_leaves<T: RlstScalar<Real = T> + Float + Default + Equivalence + Sampl
 
 /// Test that all leaves are mapped
 #[cfg(feature = "mpi")]
-fn test_n_points<T: RlstScalar<Real = T> + Float + Default + Equivalence + SampleUniform>(
+fn test_n_points<T: RlstScalarFloatMpi<Real = T> + SampleUniform>(
     world: &UserCommunicator,
     tree: &MultiNodeTree<T>,
     points_per_proc: usize,

--- a/kifmm/src/fmm/builder.rs
+++ b/kifmm/src/fmm/builder.rs
@@ -16,7 +16,7 @@ use crate::traits::{
     tree::{FmmTree, Tree},
 };
 use crate::tree::{
-    constants::{ALPHA_INNER, ALPHA_OUTER, ROOT},
+    constants::{ALPHA_INNER, ALPHA_OUTER},
     types::{Domain, MortonKey, SingleNodeTree},
 };
 use green_kernels::{traits::Kernel, types::EvalType};
@@ -210,7 +210,7 @@ where
 impl<T, U, V, W> KiFmm<T, U, V, W>
 where
     T: FmmTree<Tree = SingleNodeTree<W>>,
-    T::Tree: Tree<Domain = Domain<W>, Scalar = W, Node = MortonKey>,
+    T::Tree: Tree<Domain = Domain<W>, Scalar = W, Node = MortonKey<W>>,
     U: SourceToTargetData,
     V: Kernel<T = W>,
     W: RlstScalar<Real = W> + Float + Default,
@@ -218,6 +218,8 @@ where
 {
     /// Calculate source and target field translation metadata
     fn set_source_and_target_operator_data(&mut self) {
+        let root = MortonKey::root();
+
         // Cast surface parameters
         let alpha_outer = W::from(ALPHA_OUTER).unwrap();
         let alpha_inner = W::from(ALPHA_INNER).unwrap();
@@ -225,11 +227,11 @@ where
 
         // Compute required surfaces
         let upward_equivalent_surface =
-            ROOT.surface_grid(self.expansion_order, domain, alpha_inner);
-        let upward_check_surface = ROOT.surface_grid(self.expansion_order, domain, alpha_outer);
+            root.surface_grid(self.expansion_order, domain, alpha_inner);
+        let upward_check_surface = root.surface_grid(self.expansion_order, domain, alpha_outer);
         let downward_equivalent_surface =
-            ROOT.surface_grid(self.expansion_order, domain, alpha_outer);
-        let downward_check_surface = ROOT.surface_grid(self.expansion_order, domain, alpha_inner);
+            root.surface_grid(self.expansion_order, domain, alpha_outer);
+        let downward_check_surface = root.surface_grid(self.expansion_order, domain, alpha_inner);
 
         let nequiv_surface = upward_equivalent_surface.len() / self.dim;
         let ncheck_surface = upward_check_surface.len() / self.dim;
@@ -280,7 +282,7 @@ where
         let dc2e_inv_2 = ut;
 
         // Calculate M2M and L2L operator matrices
-        let children = ROOT.children();
+        let children = root.children();
         let mut m2m = rlst_dynamic_array2!(W, [nequiv_surface, 8 * nequiv_surface]);
         let mut m2m_vec = Vec::new();
 

--- a/kifmm/src/fmm/builder.rs
+++ b/kifmm/src/fmm/builder.rs
@@ -30,7 +30,7 @@ use super::constants::DEFAULT_NCRIT;
 
 impl<T, U, V> SingleNodeBuilder<T, U, V>
 where
-    T: ConfigureSourceToTargetData<Kernel = V, Domain = Domain<U>> + Default,
+    T: ConfigureSourceToTargetData<U, Kernel = V, Domain = Domain<U>> + Default,
     U: RlstScalarFloat<Real = U>,
     Array<U, BaseArray<U, VectorContainer<U>, 2>, 2>: MatrixSvd<Item = U>,
     V: Kernel<T = U> + Clone + Default,

--- a/kifmm/src/fmm/builder.rs
+++ b/kifmm/src/fmm/builder.rs
@@ -19,11 +19,11 @@ use crate::tree::{
     constants::{ALPHA_INNER, ALPHA_OUTER},
     types::{Domain, MortonKey, SingleNodeTree},
 };
+use crate::RlstScalarFloat;
 use green_kernels::{traits::Kernel, types::EvalType};
-use num::Float;
 use rlst::{
     empty_array, rlst_dynamic_array2, Array, BaseArray, MatrixSvd, MultIntoResize, RawAccess,
-    RawAccessMut, RlstScalar, Shape, VectorContainer,
+    RawAccessMut, Shape, VectorContainer,
 };
 
 use super::constants::DEFAULT_NCRIT;
@@ -31,7 +31,7 @@ use super::constants::DEFAULT_NCRIT;
 impl<T, U, V> SingleNodeBuilder<T, U, V>
 where
     T: ConfigureSourceToTargetData<Kernel = V, Domain = Domain<U>> + Default,
-    U: RlstScalar<Real = U> + Float + Default,
+    U: RlstScalarFloat<Real = U>,
     Array<U, BaseArray<U, VectorContainer<U>, 2>, 2>: MatrixSvd<Item = U>,
     V: Kernel<T = U> + Clone + Default,
 {
@@ -213,7 +213,7 @@ where
     T::Tree: Tree<Domain = Domain<W>, Scalar = W, Node = MortonKey<W>>,
     U: SourceToTargetData,
     V: Kernel<T = W>,
-    W: RlstScalar<Real = W> + Float + Default,
+    W: RlstScalarFloat<Real = W>,
     Array<W, BaseArray<W, VectorContainer<W>, 2>, 2>: MatrixSvd<Item = W>,
 {
     /// Calculate source and target field translation metadata

--- a/kifmm/src/fmm/field_translation/source.rs
+++ b/kifmm/src/fmm/field_translation/source.rs
@@ -29,7 +29,7 @@ where
     U: SourceToTargetData + Send + Sync,
     V: Kernel<T = W>,
     W: RlstScalarFloat,
-    <W as RlstScalar>::Real: RlstScalarFloat
+    <W as RlstScalar>::Real: RlstScalarFloat,
 {
     fn p2m(&self) {
         let Some(_leaves) = self.tree.source_tree().all_leaves() else {
@@ -136,9 +136,9 @@ where
                     .zip(&self.charge_index_pointer_sources)
                     .for_each(
                         |((check_potential, upward_check_surface), charge_index_pointer)| {
-                            let coordinates_row_major: &[W::Real] = &coordinates[charge_index_pointer.0
-                                * self.dim
-                                ..charge_index_pointer.1 * self.dim];
+                            let coordinates_row_major: &[W::Real] = &coordinates
+                                [charge_index_pointer.0 * self.dim
+                                    ..charge_index_pointer.1 * self.dim];
                             let nsources = coordinates_row_major.len() / self.dim;
 
                             if nsources > 0 {

--- a/kifmm/src/fmm/field_translation/source.rs
+++ b/kifmm/src/fmm/field_translation/source.rs
@@ -1,10 +1,13 @@
 //! Multipole Translations
-use crate::{traits::{
-    field::SourceToTargetData,
-    fmm::SourceTranslation,
-    tree::{FmmTree, Tree},
-}, RlstScalarFloat};
 use crate::tree::{constants::NSIBLINGS, types::SingleNodeTree};
+use crate::{
+    traits::{
+        field::SourceToTargetData,
+        fmm::SourceTranslation,
+        tree::{FmmTree, Tree},
+    },
+    RlstScalarFloat,
+};
 use green_kernels::{traits::Kernel, types::EvalType};
 use itertools::Itertools;
 use rayon::prelude::*;

--- a/kifmm/src/fmm/field_translation/source.rs
+++ b/kifmm/src/fmm/field_translation/source.rs
@@ -25,7 +25,7 @@ use rlst::{
 
 impl<T, U, V, W> SourceTranslation for KiFmm<T, U, V, W>
 where
-    T: FmmTree<Tree = SingleNodeTree<W>> + Send + Sync,
+    T: FmmTree<Tree = SingleNodeTree<W::Real>> + Send + Sync,
     U: SourceToTargetData + Send + Sync,
     V: Kernel<T = W>,
     W: RlstScalarFloat,

--- a/kifmm/src/fmm/field_translation/source.rs
+++ b/kifmm/src/fmm/field_translation/source.rs
@@ -1,13 +1,12 @@
 //! Multipole Translations
-use crate::traits::{
+use crate::{traits::{
     field::SourceToTargetData,
     fmm::SourceTranslation,
     tree::{FmmTree, Tree},
-};
+}, RlstScalarFloat};
 use crate::tree::{constants::NSIBLINGS, types::SingleNodeTree};
 use green_kernels::{traits::Kernel, types::EvalType};
 use itertools::Itertools;
-use num::Float;
 use rayon::prelude::*;
 use std::collections::HashSet;
 
@@ -18,7 +17,7 @@ use crate::fmm::{
 };
 use rlst::{
     empty_array, rlst_array_from_slice2, rlst_dynamic_array2, MultIntoResize, RawAccess,
-    RawAccessMut, RlstScalar,
+    RawAccessMut,
 };
 
 impl<T, U, V, W> SourceTranslation for KiFmm<T, U, V, W>
@@ -26,7 +25,7 @@ where
     T: FmmTree<Tree = SingleNodeTree<W>> + Send + Sync,
     U: SourceToTargetData + Send + Sync,
     V: Kernel<T = W>,
-    W: RlstScalar<Real = W> + Float + Default,
+    W: RlstScalarFloat<Real = W>,
 {
     fn p2m(&self) {
         let Some(_leaves) = self.tree.source_tree().all_leaves() else {

--- a/kifmm/src/fmm/field_translation/source_to_target/blas.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/blas.rs
@@ -14,7 +14,8 @@ use itertools::Itertools;
 
 use rayon::prelude::*;
 use rlst::{
-    empty_array, rlst_array_from_slice2, rlst_dynamic_array2, Array, BaseArray, MatrixSvd, MultIntoResize, RawAccess, RawAccessMut, RlstScalar, VectorContainer
+    empty_array, rlst_array_from_slice2, rlst_dynamic_array2, Array, BaseArray, MatrixSvd,
+    MultIntoResize, RawAccess, RawAccessMut, RlstScalar, VectorContainer,
 };
 use std::{
     collections::{HashMap, HashSet},

--- a/kifmm/src/fmm/field_translation/source_to_target/blas.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/blas.rs
@@ -28,7 +28,7 @@ where
     U: RlstScalarFloat,
     <U as RlstScalar>::Real: RlstScalarFloat,
     Array<U, BaseArray<U, VectorContainer<U>, 2>, 2>: MatrixSvd<Item = U>,
-    V: FmmTree<Tree = SingleNodeTree<U>> + Send + Sync,
+    V: FmmTree<Tree = SingleNodeTree<U::Real>> + Send + Sync,
 {
     /// Displacements
     pub fn displacements(&self, level: u64) -> Vec<Mutex<Vec<i64>>> {

--- a/kifmm/src/fmm/field_translation/source_to_target/blas.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/blas.rs
@@ -14,8 +14,7 @@ use itertools::Itertools;
 
 use rayon::prelude::*;
 use rlst::{
-    empty_array, rlst_array_from_slice2, rlst_dynamic_array2, Array, BaseArray, MatrixSvd,
-    MultIntoResize, RawAccess, RawAccessMut, VectorContainer,
+    empty_array, rlst_array_from_slice2, rlst_dynamic_array2, Array, BaseArray, MatrixSvd, MultIntoResize, RawAccess, RawAccessMut, RlstScalar, VectorContainer
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -25,7 +24,8 @@ use std::{
 impl<T, U, V> KiFmm<V, BlasFieldTranslation<U, T>, T, U>
 where
     T: Kernel<T = U> + std::marker::Send + std::marker::Sync + Default,
-    U: RlstScalarFloat<Real = U>,
+    U: RlstScalarFloat,
+    <U as RlstScalar>::Real: RlstScalarFloat,
     Array<U, BaseArray<U, VectorContainer<U>, 2>, 2>: MatrixSvd<Item = U>,
     V: FmmTree<Tree = SingleNodeTree<U>> + Send + Sync,
 {

--- a/kifmm/src/fmm/field_translation/source_to_target/blas.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/blas.rs
@@ -8,13 +8,14 @@ use crate::traits::{
     tree::{FmmTree, Tree},
 };
 use crate::tree::{constants::NTRANSFER_VECTORS_KIFMM, types::SingleNodeTree};
+use crate::RlstScalarFloat;
 use green_kernels::traits::Kernel;
 use itertools::Itertools;
-use num::Float;
+
 use rayon::prelude::*;
 use rlst::{
     empty_array, rlst_array_from_slice2, rlst_dynamic_array2, Array, BaseArray, MatrixSvd,
-    MultIntoResize, RawAccess, RawAccessMut, RlstScalar, VectorContainer,
+    MultIntoResize, RawAccess, RawAccessMut, VectorContainer,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -24,7 +25,7 @@ use std::{
 impl<T, U, V> KiFmm<V, BlasFieldTranslation<U, T>, T, U>
 where
     T: Kernel<T = U> + std::marker::Send + std::marker::Sync + Default,
-    U: RlstScalar<Real = U> + Float + Default,
+    U: RlstScalarFloat<Real = U>,
     Array<U, BaseArray<U, VectorContainer<U>, 2>, 2>: MatrixSvd<Item = U>,
     V: FmmTree<Tree = SingleNodeTree<U>> + Send + Sync,
 {
@@ -90,7 +91,7 @@ where
 impl<T, U, V> SourceToTargetTranslation for KiFmm<V, BlasFieldTranslation<U, T>, T, U>
 where
     T: Kernel<T = U> + std::marker::Send + std::marker::Sync + Default,
-    U: RlstScalar<Real = U> + Float + Default,
+    U: RlstScalarFloat<Real = U>,
     Array<U, BaseArray<U, VectorContainer<U>, 2>, 2>: MatrixSvd<Item = U>,
     V: FmmTree<Tree = SingleNodeTree<U>> + Send + Sync,
 {

--- a/kifmm/src/fmm/field_translation/source_to_target/fft.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/fft.rs
@@ -8,10 +8,11 @@ use crate::tree::{
     constants::{NHALO, NSIBLINGS},
     types::{MortonKey, SingleNodeTree},
 };
+use crate::RlstScalarFloat;
 
 use green_kernels::traits::Kernel;
 use itertools::Itertools;
-use num::{Complex, Float};
+use num::{Complex};
 use num_complex::ComplexFloat;
 use rayon::prelude::*;
 use rlst::BaseArray;
@@ -24,7 +25,7 @@ use std::{collections::HashSet, sync::RwLock};
 impl<T, U, V> KiFmm<V, FftFieldTranslation<U, T>, T, U>
 where
     T: Kernel<T = U> + std::marker::Send + std::marker::Sync + Default,
-    U: RlstScalar<Real = U> + Float + Default + RealToComplexFft3D,
+    U: RlstScalarFloat<Real = U> + RealToComplexFft3D,
     Complex<U>: RlstScalar,
     Array<U, BaseArray<U, VectorContainer<U>, 2>, 2>: MatrixSvd<Item = U>,
     V: FmmTree<Tree = SingleNodeTree<U>> + Send + Sync,
@@ -84,7 +85,7 @@ where
 impl<T, U, V> SourceToTargetTranslation for KiFmm<V, FftFieldTranslation<U, T>, T, U>
 where
     T: Kernel<T = U> + Default + Send + Sync,
-    U: RlstScalar<Real = U> + Float + Default + RealToComplexFft3D,
+    U: RlstScalarFloat<Real = U> +RealToComplexFft3D,
     Complex<U>: RlstScalar,
     Array<U, BaseArray<U, VectorContainer<U>, 2>, 2>: MatrixSvd<Item = U>,
     V: FmmTree<Tree = SingleNodeTree<U>> + Send + Sync,

--- a/kifmm/src/fmm/field_translation/source_to_target/fft.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/fft.rs
@@ -33,7 +33,7 @@ where
     fn displacements(&self, level: u64) -> Vec<RwLock<Vec<usize>>> {
         let targets = self.tree.target_tree().keys(level).unwrap();
 
-        let targets_parents: HashSet<MortonKey> =
+        let targets_parents: HashSet<MortonKey<_>> =
             targets.iter().map(|target| target.parent()).collect();
         let mut targets_parents = targets_parents.into_iter().collect_vec();
         targets_parents.sort();
@@ -41,7 +41,7 @@ where
 
         let sources = self.tree.source_tree().keys(level).unwrap();
 
-        let sources_parents: HashSet<MortonKey> =
+        let sources_parents: HashSet<MortonKey<_>> =
             sources.iter().map(|source| source.parent()).collect();
         let mut sources_parents = sources_parents.into_iter().collect_vec();
         sources_parents.sort();
@@ -110,13 +110,13 @@ where
                 let nconv_pad = nconv + 1;
 
                 // Find parents of targets
-                let targets_parents: HashSet<MortonKey> =
+                let targets_parents: HashSet<MortonKey<_>> =
                     targets.iter().map(|target| target.parent()).collect();
 
                 let targets_parents = targets_parents.into_iter().collect_vec();
                 let ntargets_parents = targets_parents.len();
 
-                let sources_parents: HashSet<MortonKey> =
+                let sources_parents: HashSet<MortonKey<_>> =
                     sources.iter().map(|source| source.parent()).collect();
                 let nsources_parents = sources_parents.len();
 

--- a/kifmm/src/fmm/field_translation/source_to_target/fft.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/fft.rs
@@ -8,17 +8,16 @@ use crate::tree::{
     constants::{NHALO, NSIBLINGS},
     types::{MortonKey, SingleNodeTree},
 };
-use crate::RlstScalarFloat;
+use crate::{RlstScalarComplexFloat, RlstScalarFloat};
 
 use green_kernels::traits::Kernel;
 use itertools::Itertools;
 use num::Complex;
-use num_complex::ComplexFloat;
 use rayon::prelude::*;
+use rlst::Array;
 use rlst::BaseArray;
 use rlst::VectorContainer;
 use rlst::{empty_array, rlst_dynamic_array2, MultIntoResize, RawAccess};
-use rlst::{Array, RlstScalar};
 use rlst::{MatrixSvd, RandomAccessMut};
 use std::{collections::HashSet, sync::RwLock};
 
@@ -26,10 +25,9 @@ impl<T, U, V> KiFmm<V, FftFieldTranslation<U, T>, T, U>
 where
     T: Kernel<T = U> + std::marker::Send + std::marker::Sync + Default,
     U: RlstScalarFloat<Real = U> + RealToComplexFft3D,
-    Complex<U>: RlstScalar,
     Array<U, BaseArray<U, VectorContainer<U>, 2>, 2>: MatrixSvd<Item = U>,
     V: FmmTree<Tree = SingleNodeTree<U>> + Send + Sync,
-    Complex<U>: ComplexFloat,
+    Complex<U>: RlstScalarComplexFloat,
 {
     fn displacements(&self, level: u64) -> Vec<RwLock<Vec<usize>>> {
         let targets = self.tree.target_tree().keys(level).unwrap();
@@ -86,10 +84,9 @@ impl<T, U, V> SourceToTargetTranslation for KiFmm<V, FftFieldTranslation<U, T>, 
 where
     T: Kernel<T = U> + Default + Send + Sync,
     U: RlstScalarFloat<Real = U> + RealToComplexFft3D,
-    Complex<U>: RlstScalar,
     Array<U, BaseArray<U, VectorContainer<U>, 2>, 2>: MatrixSvd<Item = U>,
     V: FmmTree<Tree = SingleNodeTree<U>> + Send + Sync,
-    Complex<U>: ComplexFloat,
+    Complex<U>: RlstScalarComplexFloat,
 {
     fn m2l(&self, level: u64) {
         match self.fmm_eval_type {

--- a/kifmm/src/fmm/field_translation/source_to_target/fft.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/fft.rs
@@ -12,7 +12,7 @@ use crate::RlstScalarFloat;
 
 use green_kernels::traits::Kernel;
 use itertools::Itertools;
-use num::{Complex};
+use num::Complex;
 use num_complex::ComplexFloat;
 use rayon::prelude::*;
 use rlst::BaseArray;
@@ -85,7 +85,7 @@ where
 impl<T, U, V> SourceToTargetTranslation for KiFmm<V, FftFieldTranslation<U, T>, T, U>
 where
     T: Kernel<T = U> + Default + Send + Sync,
-    U: RlstScalarFloat<Real = U> +RealToComplexFft3D,
+    U: RlstScalarFloat<Real = U> + RealToComplexFft3D,
     Complex<U>: RlstScalar,
     Array<U, BaseArray<U, VectorContainer<U>, 2>, 2>: MatrixSvd<Item = U>,
     V: FmmTree<Tree = SingleNodeTree<U>> + Send + Sync,

--- a/kifmm/src/fmm/field_translation/source_to_target/metadata.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/metadata.rs
@@ -12,11 +12,10 @@ use crate::tree::{
     helpers::find_corners,
     types::{Domain, MortonKey},
 };
-use crate::RlstScalarFloat;
+use crate::{RlstScalarComplexFloat, RlstScalarFloat};
 use green_kernels::{traits::Kernel, types::EvalType};
 use itertools::Itertools;
 use num::{Complex, Float, Zero};
-use num_complex::ComplexFloat;
 use rlst::{
     empty_array, rlst_array_from_slice2, rlst_dynamic_array2, rlst_dynamic_array3, Array,
     BaseArray, Gemm, MatrixSvd, MultIntoResize, RawAccess, RawAccessMut, RlstScalar, Shape,
@@ -243,7 +242,7 @@ where
 impl<T, U> SourceToTargetData for FftFieldTranslation<T, U>
 where
     T: RlstScalarFloat<Real = T> + RealToComplexFft3D,
-    Complex<T>: RlstScalar + ComplexFloat,
+    Complex<T>: RlstScalarComplexFloat,
     U: Kernel<T = T> + Default,
 {
     type Metadata = FftMetadata<Complex<T>>;
@@ -252,7 +251,7 @@ where
 impl<T, U> ConfigureSourceToTargetData<T> for FftFieldTranslation<T, U>
 where
     T: RlstScalarFloat<Real = T> + RealToComplexFft3D,
-    Complex<T>: RlstScalar + ComplexFloat,
+    Complex<T>: RlstScalarComplexFloat,
     U: Kernel<T = T> + Default,
 {
     type Domain = Domain<T>;
@@ -466,7 +465,7 @@ where
 impl<T, U> FftFieldTranslation<T, U>
 where
     T: RlstScalarFloat<Real = T> + RealToComplexFft3D,
-    Complex<T>: RlstScalar + ComplexFloat,
+    Complex<T>: RlstScalarComplexFloat,
     U: Kernel<T = T> + Default,
 {
     /// Create new

--- a/kifmm/src/fmm/field_translation/source_to_target/metadata.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/metadata.rs
@@ -12,6 +12,7 @@ use crate::tree::{
     helpers::find_corners,
     types::{Domain, MortonKey},
 };
+use crate::RlstScalarFloat;
 use green_kernels::{traits::Kernel, types::EvalType};
 use itertools::Itertools;
 use num::{Complex, Float, Zero};
@@ -40,7 +41,7 @@ fn find_cutoff_rank<T: Float + Default + RlstScalar<Real = T> + Gemm>(
 impl<T, U> SourceToTargetData for BlasFieldTranslation<T, U>
 where
     T: Float + Default,
-    T: RlstScalar<Real = T> + Gemm,
+    T: RlstScalarFloat<Real = T>,
     U: Kernel<T = T> + Default,
     Array<T, BaseArray<T, VectorContainer<T>, 2>, 2>: MatrixSvd<Item = T>,
 {
@@ -49,7 +50,7 @@ where
 
 impl<T, U> ConfigureSourceToTargetData for BlasFieldTranslation<T, U>
 where
-    T: Float + Default + RlstScalar<Real = T> + Gemm,
+    T: RlstScalarFloat<Real = T>,
     U: Kernel<T = T> + Default,
     Array<T, BaseArray<T, VectorContainer<T>, 2>, 2>: MatrixSvd<Item = T>,
 {
@@ -223,7 +224,7 @@ where
 impl<T, U> BlasFieldTranslation<T, U>
 where
     T: Float + Default,
-    T: RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
     U: Kernel<T = T> + Default,
     Array<T, BaseArray<T, VectorContainer<T>, 2>, 2>: MatrixSvd<Item = T>,
 {
@@ -240,7 +241,7 @@ where
 
 impl<T, U> SourceToTargetData for FftFieldTranslation<T, U>
 where
-    T: RlstScalar<Real = T> + Float + Default + RealToComplexFft3D,
+    T: RlstScalarFloat<Real = T> + RealToComplexFft3D,
     Complex<T>: RlstScalar + ComplexFloat,
     U: Kernel<T = T> + Default,
 {
@@ -249,7 +250,7 @@ where
 
 impl<T, U> ConfigureSourceToTargetData for FftFieldTranslation<T, U>
 where
-    T: RlstScalar<Real = T> + Float + Default + RealToComplexFft3D,
+    T: RlstScalarFloat<Real = T> + RealToComplexFft3D,
     Complex<T>: RlstScalar + ComplexFloat,
     U: Kernel<T = T> + Default,
 {
@@ -463,7 +464,7 @@ where
 
 impl<T, U> FftFieldTranslation<T, U>
 where
-    T: Float + RlstScalar<Real = T> + Default + RealToComplexFft3D,
+    T: RlstScalarFloat<Real = T> + RealToComplexFft3D,
     Complex<T>: RlstScalar + ComplexFloat,
     U: Kernel<T = T> + Default,
 {
@@ -612,11 +613,7 @@ mod test {
     fn test_blas_field_translation() {
         let kernel = Laplace3dKernel::new();
         let expansion_order = 6;
-
-        let domain = Domain {
-            origin: [0., 0., 0.],
-            side_length: [1., 1., 1.],
-        };
+        let domain = Domain::<f64>::new(&[0., 0., 0.], &[1., 1., 1.]);
         let alpha = 1.05;
         let threshold = 1e-5;
         let cutoff_rank = 1000;

--- a/kifmm/src/fmm/field_translation/source_to_target/metadata.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/metadata.rs
@@ -335,7 +335,7 @@ where
                     source.surface_grid(expansion_order, &domain, alpha);
                 let target_check_surface = target.surface_grid(expansion_order, &domain, alpha);
 
-                let v_list: HashSet<MortonKey> = target
+                let v_list: HashSet<MortonKey<_>> = target
                     .parent()
                     .neighbors()
                     .iter()

--- a/kifmm/src/fmm/field_translation/source_to_target/transfer_vector.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/transfer_vector.rs
@@ -11,8 +11,7 @@ use std::collections::HashSet;
 /// with respect to level 3 of an associated octree.
 pub fn compute_transfer_vectors<T>() -> Vec<TransferVector<T>>
 where
-    T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat,
+    T: RlstScalarFloat<Real = T>,
 {
     let half = T::from(0.5).unwrap().re();
     let zero = T::zero().re();

--- a/kifmm/src/fmm/field_translation/source_to_target/transfer_vector.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/transfer_vector.rs
@@ -3,7 +3,6 @@ use crate::fmm::types::TransferVector;
 use crate::tree::types::{Domain, MortonKey};
 use crate::RlstScalarFloat;
 use itertools::Itertools;
-use rlst::RlstScalar;
 use std::collections::HashSet;
 
 /// Unique M2L interactions for homogenous, translationally invariant kernel functions (e.g. Laplace/Helmholtz).

--- a/kifmm/src/fmm/field_translation/source_to_target/transfer_vector.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/transfer_vector.rs
@@ -1,15 +1,14 @@
 //! Functions for handling transfer vectors
 use crate::fmm::types::TransferVector;
 use crate::tree::types::{Domain, MortonKey};
+use crate::RlstScalarFloat;
 use itertools::Itertools;
-use num::Float;
 use std::collections::HashSet;
-use std::fmt::Debug;
 
 /// Unique M2L interactions for homogenous, translationally invariant kernel functions (e.g. Laplace/Helmholtz).
 /// There are at most 316 such interactions, corresponding to unique `transfer vectors'. Here we compute all of them
 /// with respect to level 3 of an associated octree.
-pub fn compute_transfer_vectors<T: Float + Default + Debug>() -> Vec<TransferVector<T>> {
+pub fn compute_transfer_vectors<T: RlstScalarFloat>() -> Vec<TransferVector<T>> {
     let half = T::from(0.5).unwrap();
     let zero = T::zero();
     let one = T::one();

--- a/kifmm/src/fmm/field_translation/source_to_target/transfer_vector.rs
+++ b/kifmm/src/fmm/field_translation/source_to_target/transfer_vector.rs
@@ -3,23 +3,25 @@ use crate::fmm::types::TransferVector;
 use crate::tree::types::{Domain, MortonKey};
 use crate::RlstScalarFloat;
 use itertools::Itertools;
+use rlst::RlstScalar;
 use std::collections::HashSet;
 
 /// Unique M2L interactions for homogenous, translationally invariant kernel functions (e.g. Laplace/Helmholtz).
 /// There are at most 316 such interactions, corresponding to unique `transfer vectors'. Here we compute all of them
 /// with respect to level 3 of an associated octree.
-pub fn compute_transfer_vectors<T: RlstScalarFloat>() -> Vec<TransferVector<T>> {
-    let half = T::from(0.5).unwrap();
-    let zero = T::zero();
-    let one = T::one();
+pub fn compute_transfer_vectors<T>() -> Vec<TransferVector<T>>
+where
+    T: RlstScalarFloat,
+    <T as RlstScalar>::Real: RlstScalarFloat,
+{
+    let half = T::from(0.5).unwrap().re();
+    let zero = T::zero().re();
+    let one = T::one().re();
     let point = [half, half, half];
-    let domain = Domain {
-        origin: [zero, zero, zero],
-        side_length: [one, one, one],
-    };
+    let domain = Domain::<T::Real>::new(&[zero, zero, zero], &[one, one, one]);
 
     // Encode point in centre of domain
-    let key = MortonKey::from_point(&point, &domain, 3);
+    let key = MortonKey::<T::Real>::from_point(&point, &domain, 3);
 
     // Add neighbours, and their resp. siblings to v list.
     let mut neighbours = key.neighbors();

--- a/kifmm/src/fmm/field_translation/target.rs
+++ b/kifmm/src/fmm/field_translation/target.rs
@@ -30,7 +30,7 @@ where
     U: SourceToTargetData + Send + Sync,
     V: Kernel<T = W>,
     W: RlstScalarFloat,
-    <W as RlstScalar>::Real: RlstScalarFloat
+    <W as RlstScalar>::Real: RlstScalarFloat,
 {
     fn l2l(&self, level: u64) {
         let Some(child_targets) = self.tree.target_tree().keys(level) else {

--- a/kifmm/src/fmm/field_translation/target.rs
+++ b/kifmm/src/fmm/field_translation/target.rs
@@ -15,13 +15,13 @@ use crate::tree::{
     constants::NSIBLINGS,
     types::{MortonKey, SingleNodeTree},
 };
+use crate::RlstScalarFloat;
 use green_kernels::traits::Kernel;
 use itertools::Itertools;
-use num::Float;
 use rayon::prelude::*;
 use rlst::{
     empty_array, rlst_array_from_slice2, rlst_dynamic_array2, MultIntoResize, RawAccess,
-    RawAccessMut, RlstScalar,
+    RawAccessMut,
 };
 
 impl<T, U, V, W> TargetTranslation for KiFmm<T, U, V, W>
@@ -29,7 +29,7 @@ where
     T: FmmTree<Tree = SingleNodeTree<W>, Node = MortonKey<W>> + Send + Sync,
     U: SourceToTargetData + Send + Sync,
     V: Kernel<T = W>,
-    W: RlstScalar<Real = W> + Float + Default,
+    W: RlstScalarFloat<Real = W>,
 {
     fn l2l(&self, level: u64) {
         let Some(child_targets) = self.tree.target_tree().keys(level) else {

--- a/kifmm/src/fmm/field_translation/target.rs
+++ b/kifmm/src/fmm/field_translation/target.rs
@@ -21,15 +21,16 @@ use itertools::Itertools;
 use rayon::prelude::*;
 use rlst::{
     empty_array, rlst_array_from_slice2, rlst_dynamic_array2, MultIntoResize, RawAccess,
-    RawAccessMut,
+    RawAccessMut, RlstScalar,
 };
 
 impl<T, U, V, W> TargetTranslation for KiFmm<T, U, V, W>
 where
-    T: FmmTree<Tree = SingleNodeTree<W>, Node = MortonKey<W>> + Send + Sync,
+    T: FmmTree<Tree = SingleNodeTree<W>, Node = MortonKey<W::Real>> + Send + Sync,
     U: SourceToTargetData + Send + Sync,
     V: Kernel<T = W>,
-    W: RlstScalarFloat<Real = W>,
+    W: RlstScalarFloat,
+    <W as RlstScalar>::Real: RlstScalarFloat
 {
     fn l2l(&self, level: u64) {
         let Some(child_targets) = self.tree.target_tree().keys(level) else {
@@ -202,7 +203,7 @@ where
                                     [self.dim, 1]
                                 );
                                 let mut target_coordinates_col_major =
-                                    rlst_dynamic_array2!(W, [ntargets, self.dim]);
+                                    rlst_dynamic_array2!(W::Real, [ntargets, self.dim]);
                                 target_coordinates_col_major
                                     .fill_from(target_coordinates_row_major.view());
 
@@ -258,7 +259,7 @@ where
                                         [self.dim, 1]
                                     );
                                     let mut target_coordinates_col_major =
-                                        rlst_dynamic_array2!(W, [ntargets, self.dim]);
+                                        rlst_dynamic_array2!(W::Real, [ntargets, self.dim]);
                                     target_coordinates_col_major
                                         .fill_from(target_coordinates_row_major.view());
 
@@ -321,7 +322,7 @@ where
                                 [self.dim, 1]
                             );
                             let mut target_coordinates_col_major =
-                                rlst_dynamic_array2!(W, [ntargets, self.dim]);
+                                rlst_dynamic_array2!(W::Real, [ntargets, self.dim]);
                             target_coordinates_col_major
                                 .fill_from(target_coordinates_row_major.view());
 
@@ -359,7 +360,7 @@ where
                                             [self.dim, 1]
                                         );
                                         let mut source_coordinates_col_major =
-                                            rlst_dynamic_array2!(W, [nsources, self.dim]);
+                                            rlst_dynamic_array2!(W::Real, [nsources, self.dim]);
                                         source_coordinates_col_major
                                             .fill_from(source_coordinates_row_major.view());
 
@@ -405,7 +406,7 @@ where
                                     [self.dim, 1]
                                 );
                                 let mut target_coordinates_col_major =
-                                    rlst_dynamic_array2!(W, [ntargets, self.dim]);
+                                    rlst_dynamic_array2!(W::Real, [ntargets, self.dim]);
                                 target_coordinates_col_major
                                     .fill_from(target_coordinates_row_major.view());
 
@@ -446,7 +447,7 @@ where
                                             [self.dim, 1]
                                         );
                                         let mut source_coordinates_col_major =
-                                            rlst_dynamic_array2!(W, [nsources, self.dim]);
+                                            rlst_dynamic_array2!(W::Real, [nsources, self.dim]);
                                         source_coordinates_col_major
                                             .fill_from(source_coordinates_row_major.view());
 

--- a/kifmm/src/fmm/field_translation/target.rs
+++ b/kifmm/src/fmm/field_translation/target.rs
@@ -26,7 +26,7 @@ use rlst::{
 
 impl<T, U, V, W> TargetTranslation for KiFmm<T, U, V, W>
 where
-    T: FmmTree<Tree = SingleNodeTree<W>, Node = MortonKey> + Send + Sync,
+    T: FmmTree<Tree = SingleNodeTree<W>, Node = MortonKey<W>> + Send + Sync,
     U: SourceToTargetData + Send + Sync,
     V: Kernel<T = W>,
     W: RlstScalar<Real = W> + Float + Default,
@@ -36,7 +36,7 @@ where
             return;
         };
 
-        let parent_sources: HashSet<MortonKey> =
+        let parent_sources: HashSet<MortonKey<_>> =
             child_targets.iter().map(|source| source.parent()).collect();
         let mut parent_sources = parent_sources.into_iter().collect_vec();
         parent_sources.sort();

--- a/kifmm/src/fmm/field_translation/target.rs
+++ b/kifmm/src/fmm/field_translation/target.rs
@@ -26,7 +26,7 @@ use rlst::{
 
 impl<T, U, V, W> TargetTranslation for KiFmm<T, U, V, W>
 where
-    T: FmmTree<Tree = SingleNodeTree<W>, Node = MortonKey<W::Real>> + Send + Sync,
+    T: FmmTree<Tree = SingleNodeTree<W::Real>, Node = MortonKey<W::Real>> + Send + Sync,
     U: SourceToTargetData + Send + Sync,
     V: Kernel<T = W>,
     W: RlstScalarFloat,

--- a/kifmm/src/fmm/helpers.rs
+++ b/kifmm/src/fmm/helpers.rs
@@ -3,7 +3,7 @@ use crate::fmm::types::{Charges, SendPtrMut};
 use crate::traits::tree::{FmmTreeNode, Tree};
 use crate::tree::types::{MortonKey, SingleNodeTree};
 use crate::RlstScalarFloat;
-use num::{Num};
+use num::Num;
 use rlst::{
     rlst_dynamic_array2, rlst_dynamic_array3, Array, BaseArray, RandomAccessByRef, RandomAccessMut,
     RawAccess, RawAccessMut, RlstScalar, Shape, VectorContainer,

--- a/kifmm/src/fmm/helpers.rs
+++ b/kifmm/src/fmm/helpers.rs
@@ -166,7 +166,8 @@ pub fn level_expansion_pointers<T>(
     expansions: &[T],
 ) -> Vec<Vec<Vec<SendPtrMut<T>>>>
 where
-    T: RlstScalarFloat<Real = T>,
+    T: RlstScalarFloat,
+    <T as RlstScalar>::Real: RlstScalarFloat
 {
     let mut result = vec![Vec::new(); (tree.depth() + 1).try_into().unwrap()];
 
@@ -204,7 +205,8 @@ pub fn leaf_expansion_pointers<T>(
     expansions: &[T],
 ) -> Vec<Vec<SendPtrMut<T>>>
 where
-    T: RlstScalarFloat<Real = T>,
+    T: RlstScalarFloat,
+    <T as RlstScalar>::Real: RlstScalarFloat
 {
     let mut result = vec![Vec::new(); n_leaves];
 
@@ -236,7 +238,8 @@ pub fn potential_pointers<T>(
     potentials: &[T],
 ) -> Vec<SendPtrMut<T>>
 where
-    T: RlstScalarFloat<Real = T>,
+    T: RlstScalarFloat,
+    <T as RlstScalar>::Real: RlstScalarFloat
 {
     let mut result = vec![SendPtrMut::default(); n_leaves * nmatvecs];
     let dim = 3;

--- a/kifmm/src/fmm/helpers.rs
+++ b/kifmm/src/fmm/helpers.rs
@@ -160,7 +160,7 @@ where
 
 /// Create mutable pointers corresponding to each multipole expansion at each level of an octree
 pub fn level_expansion_pointers<T>(
-    tree: &SingleNodeTree<T>,
+    tree: &SingleNodeTree<T::Real>,
     ncoeffs: usize,
     nmatvecs: usize,
     expansions: &[T],
@@ -198,7 +198,7 @@ where
 
 /// Create mutable pointers for leaf expansions in a tree
 pub fn leaf_expansion_pointers<T>(
-    tree: &SingleNodeTree<T>,
+    tree: &SingleNodeTree<T::Real>,
     ncoeffs: usize,
     nmatvecs: usize,
     n_leaves: usize,
@@ -230,7 +230,7 @@ where
 
 /// Create mutable pointers for potentials in a tree
 pub fn potential_pointers<T>(
-    tree: &SingleNodeTree<T>,
+    tree: &SingleNodeTree<T::Real>,
     nmatvecs: usize,
     n_leaves: usize,
     n_points: usize,

--- a/kifmm/src/fmm/helpers.rs
+++ b/kifmm/src/fmm/helpers.rs
@@ -142,7 +142,7 @@ where
 }
 
 /// Create index pointers for each key at each level of an octree
-pub fn level_index_pointer<T>(tree: &SingleNodeTree<T>) -> Vec<HashMap<MortonKey, usize>>
+pub fn level_index_pointer<T>(tree: &SingleNodeTree<T>) -> Vec<HashMap<MortonKey<T>, usize>>
 where
     T: Float + Default + RlstScalar<Real = T>,
 {

--- a/kifmm/src/fmm/helpers.rs
+++ b/kifmm/src/fmm/helpers.rs
@@ -167,7 +167,7 @@ pub fn level_expansion_pointers<T>(
 ) -> Vec<Vec<Vec<SendPtrMut<T>>>>
 where
     T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat
+    <T as RlstScalar>::Real: RlstScalarFloat,
 {
     let mut result = vec![Vec::new(); (tree.depth() + 1).try_into().unwrap()];
 
@@ -206,7 +206,7 @@ pub fn leaf_expansion_pointers<T>(
 ) -> Vec<Vec<SendPtrMut<T>>>
 where
     T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat
+    <T as RlstScalar>::Real: RlstScalarFloat,
 {
     let mut result = vec![Vec::new(); n_leaves];
 
@@ -239,7 +239,7 @@ pub fn potential_pointers<T>(
 ) -> Vec<SendPtrMut<T>>
 where
     T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat
+    <T as RlstScalar>::Real: RlstScalarFloat,
 {
     let mut result = vec![SendPtrMut::default(); n_leaves * nmatvecs];
     let dim = 3;

--- a/kifmm/src/fmm/helpers.rs
+++ b/kifmm/src/fmm/helpers.rs
@@ -2,7 +2,8 @@
 use crate::fmm::types::{Charges, SendPtrMut};
 use crate::traits::tree::{FmmTreeNode, Tree};
 use crate::tree::types::{MortonKey, SingleNodeTree};
-use num::{Float, Num};
+use crate::RlstScalarFloat;
+use num::{Num};
 use rlst::{
     rlst_dynamic_array2, rlst_dynamic_array3, Array, BaseArray, RandomAccessByRef, RandomAccessMut,
     RawAccess, RawAccessMut, RlstScalar, Shape, VectorContainer,
@@ -71,7 +72,7 @@ pub fn m2l_scale<T: RlstScalar<Real = T>>(level: u64) -> Result<T, std::io::Erro
 /// * `ncoeffs`- Number of interpolation points on leaf box
 pub fn leaf_scales<T>(tree: &SingleNodeTree<T>, ncoeffs: usize) -> Vec<T>
 where
-    T: Float + Default + RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     let mut result = vec![T::default(); tree.n_leaves().unwrap() * ncoeffs];
 
@@ -99,7 +100,7 @@ pub fn leaf_surfaces<T>(
     expansion_order: usize,
 ) -> Vec<T>
 where
-    T: Float + Default + RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     let dim = 3;
     let n_keys = tree.n_leaves().unwrap();
@@ -120,7 +121,7 @@ where
 /// between the local indices for each leaf and their associated charges
 pub fn coordinate_index_pointer<T>(tree: &SingleNodeTree<T>) -> Vec<(usize, usize)>
 where
-    T: Float + Default + RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     let mut index_pointer = 0;
 
@@ -144,7 +145,7 @@ where
 /// Create index pointers for each key at each level of an octree
 pub fn level_index_pointer<T>(tree: &SingleNodeTree<T>) -> Vec<HashMap<MortonKey<T>, usize>>
 where
-    T: Float + Default + RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     let mut result = vec![HashMap::new(); (tree.depth() + 1).try_into().unwrap()];
 
@@ -165,7 +166,7 @@ pub fn level_expansion_pointers<T>(
     expansions: &[T],
 ) -> Vec<Vec<Vec<SendPtrMut<T>>>>
 where
-    T: Float + Default + RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     let mut result = vec![Vec::new(); (tree.depth() + 1).try_into().unwrap()];
 
@@ -203,7 +204,7 @@ pub fn leaf_expansion_pointers<T>(
     expansions: &[T],
 ) -> Vec<Vec<SendPtrMut<T>>>
 where
-    T: Float + Default + RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     let mut result = vec![Vec::new(); n_leaves];
 
@@ -235,7 +236,7 @@ pub fn potential_pointers<T>(
     potentials: &[T],
 ) -> Vec<SendPtrMut<T>>
 where
-    T: Float + Default + RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     let mut result = vec![SendPtrMut::default(); n_leaves * nmatvecs];
     let dim = 3;

--- a/kifmm/src/fmm/single_node.rs
+++ b/kifmm/src/fmm/single_node.rs
@@ -9,17 +9,18 @@ use crate::traits::{
     tree::{FmmTree, Tree},
 };
 use crate::tree::types::{MortonKey, SingleNodeTree};
+use crate::RlstScalarFloat;
 use green_kernels::traits::Kernel;
 use green_kernels::types::EvalType;
-use num::Float;
-use rlst::{rlst_dynamic_array2, RawAccess, RlstScalar, Shape};
+
+use rlst::{rlst_dynamic_array2, RawAccess, Shape};
 
 impl<T, U, V, W> Fmm for KiFmm<T, U, V, W>
 where
     T: FmmTree<Tree = SingleNodeTree<W>, Node = MortonKey<W>> + Send + Sync,
     U: SourceToTargetData + Send + Sync,
     V: Kernel<T = W> + Send + Sync,
-    W: RlstScalar<Real = W> + Float + Default,
+    W: RlstScalarFloat<Real = W>,
     Self: SourceToTargetTranslation,
 {
     type Node = T::Node;
@@ -205,7 +206,7 @@ where
     T: FmmTree<Tree = SingleNodeTree<W>> + Default,
     U: SourceToTargetData + Default,
     V: Kernel + Default,
-    W: RlstScalar<Real = W> + Float + Default,
+    W: RlstScalarFloat<Real = W>,
 {
     fn default() -> Self {
         let uc2e_inv_1 = rlst_dynamic_array2!(W, [1, 1]);
@@ -268,7 +269,7 @@ mod test {
     use rlst::RawAccessMut;
     use rlst::VectorContainer;
 
-    fn test_single_node_fmm_vector_helper<T: RlstScalar<Real = T> + Float + Default>(
+    fn test_single_node_fmm_vector_helper<T: RlstScalarFloat<Real = T>>(
         fmm: Box<
             dyn Fmm<
                 Scalar = T,
@@ -317,7 +318,7 @@ mod test {
         });
     }
 
-    fn test_single_node_fmm_matrix_helper<T: RlstScalar<Real = T> + Float + Default>(
+    fn test_single_node_fmm_matrix_helper<T: RlstScalarFloat<Real = T>>(
         fmm: Box<
             dyn Fmm<
                 Scalar = T,
@@ -633,7 +634,7 @@ mod test {
         }
     }
 
-    fn test_root_multipole_laplace_single_node<T: RlstScalar<Real = T> + Float + Default>(
+    fn test_root_multipole_laplace_single_node<T: RlstScalarFloat<Real = T>>(
         fmm: Box<
             dyn Fmm<
                 Scalar = T,

--- a/kifmm/src/fmm/single_node.rs
+++ b/kifmm/src/fmm/single_node.rs
@@ -16,7 +16,7 @@ use rlst::{rlst_dynamic_array2, RawAccess, RlstScalar, Shape};
 
 impl<T, U, V, W> Fmm for KiFmm<T, U, V, W>
 where
-    T: FmmTree<Tree = SingleNodeTree<W>, Node = MortonKey<W::Real>, Scalar = W> + Send + Sync,
+    T: FmmTree<Tree = SingleNodeTree<W::Real>, Node = MortonKey<W::Real>, Scalar = W> + Send + Sync,
     U: SourceToTargetData + Send + Sync,
     V: Kernel<T = W> + Send + Sync,
     W: RlstScalarFloat,

--- a/kifmm/src/fmm/single_node.rs
+++ b/kifmm/src/fmm/single_node.rs
@@ -16,7 +16,7 @@ use rlst::{rlst_dynamic_array2, RawAccess, RlstScalar, Shape};
 
 impl<T, U, V, W> Fmm for KiFmm<T, U, V, W>
 where
-    T: FmmTree<Tree = SingleNodeTree<W>, Node = MortonKey> + Send + Sync,
+    T: FmmTree<Tree = SingleNodeTree<W>, Node = MortonKey<W>> + Send + Sync,
     U: SourceToTargetData + Send + Sync,
     V: Kernel<T = W> + Send + Sync,
     W: RlstScalar<Real = W> + Float + Default,
@@ -256,7 +256,7 @@ mod test {
 
     use super::*;
     use crate::traits::tree::FmmTreeNode;
-    use crate::tree::constants::{ALPHA_INNER, ROOT};
+    use crate::tree::constants::ALPHA_INNER;
     use crate::tree::helpers::points_fixture;
     use crate::{BlasFieldTranslation, FftFieldTranslation, SingleNodeBuilder, SingleNodeFmmTree};
     use green_kernels::laplace_3d::Laplace3dKernel;
@@ -272,7 +272,7 @@ mod test {
         fmm: Box<
             dyn Fmm<
                 Scalar = T,
-                Node = MortonKey,
+                Node = MortonKey<T>,
                 Kernel = Laplace3dKernel<T>,
                 Tree = SingleNodeFmmTree<T>,
             >,
@@ -288,7 +288,7 @@ mod test {
         };
 
         let leaf_idx = 0;
-        let leaf: MortonKey = fmm.tree().target_tree().all_leaves().unwrap()[leaf_idx];
+        let leaf = fmm.tree().target_tree().all_leaves().unwrap()[leaf_idx];
         let potential = fmm.potential(&leaf).unwrap()[0];
 
         let leaf_targets = fmm.tree().target_tree().coordinates(&leaf).unwrap();
@@ -321,7 +321,7 @@ mod test {
         fmm: Box<
             dyn Fmm<
                 Scalar = T,
-                Node = MortonKey,
+                Node = MortonKey<T>,
                 Kernel = Laplace3dKernel<T>,
                 Tree = SingleNodeFmmTree<T>,
             >,
@@ -337,7 +337,7 @@ mod test {
         };
 
         let leaf_idx = 0;
-        let leaf: MortonKey = fmm.tree().target_tree().all_leaves().unwrap()[leaf_idx];
+        let leaf = fmm.tree().target_tree().all_leaves().unwrap()[leaf_idx];
 
         let leaf_targets = fmm.tree().target_tree().coordinates(&leaf).unwrap();
 
@@ -637,7 +637,7 @@ mod test {
         fmm: Box<
             dyn Fmm<
                 Scalar = T,
-                Node = MortonKey,
+                Node = MortonKey<T>,
                 Kernel = Laplace3dKernel<T>,
                 Tree = SingleNodeFmmTree<T>,
             >,
@@ -646,8 +646,10 @@ mod test {
         charges: &Array<T, BaseArray<T, VectorContainer<T>, 2>, 2>,
         threshold: T,
     ) {
-        let multipole = fmm.multipole(&ROOT).unwrap();
-        let upward_equivalent_surface = ROOT.surface_grid(
+        let root = MortonKey::root();
+
+        let multipole = fmm.multipole(&root).unwrap();
+        let upward_equivalent_surface = root.surface_grid(
             fmm.expansion_order(),
             fmm.tree().domain(),
             T::from(ALPHA_INNER).unwrap(),

--- a/kifmm/src/fmm/single_node.rs
+++ b/kifmm/src/fmm/single_node.rs
@@ -12,15 +12,15 @@ use crate::tree::types::{MortonKey, SingleNodeTree};
 use crate::RlstScalarFloat;
 use green_kernels::traits::Kernel;
 use green_kernels::types::EvalType;
-
-use rlst::{rlst_dynamic_array2, RawAccess, Shape};
+use rlst::{rlst_dynamic_array2, RawAccess, RlstScalar, Shape};
 
 impl<T, U, V, W> Fmm for KiFmm<T, U, V, W>
 where
-    T: FmmTree<Tree = SingleNodeTree<W>, Node = MortonKey<W>> + Send + Sync,
+    T: FmmTree<Tree = SingleNodeTree<W>, Node = MortonKey<W::Real>, Scalar = W> + Send + Sync,
     U: SourceToTargetData + Send + Sync,
     V: Kernel<T = W> + Send + Sync,
-    W: RlstScalarFloat<Real = W>,
+    W: RlstScalarFloat,
+    <W as RlstScalar>::Real: RlstScalarFloat,
     Self: SourceToTargetTranslation,
 {
     type Node = T::Node;

--- a/kifmm/src/fmm/tree.rs
+++ b/kifmm/src/fmm/tree.rs
@@ -1,4 +1,6 @@
 //! Implementation of FmmTree Trait
+use rlst::RlstScalar;
+
 use super::types::SingleNodeFmmTree;
 use crate::traits::tree::{FmmTree, Tree};
 use crate::tree::types::{MortonKey, SingleNodeTree};
@@ -6,10 +8,11 @@ use crate::RlstScalarFloat;
 
 impl<T> FmmTree for SingleNodeFmmTree<T>
 where
-    T: RlstScalarFloat<Real = T>,
+    T: RlstScalarFloat,
+    <T as RlstScalar>::Real: RlstScalarFloat
 {
     type Scalar = T;
-    type Node = MortonKey<T>;
+    type Node = MortonKey<T::Real>;
     type Tree = SingleNodeTree<T>;
 
     fn source_tree(&self) -> &Self::Tree {

--- a/kifmm/src/fmm/tree.rs
+++ b/kifmm/src/fmm/tree.rs
@@ -4,8 +4,6 @@ use crate::traits::tree::{FmmTree, Tree};
 use crate::tree::types::{MortonKey, SingleNodeTree};
 use crate::RlstScalarFloat;
 
-
-
 impl<T> FmmTree for SingleNodeFmmTree<T>
 where
     T: RlstScalarFloat<Real = T>,

--- a/kifmm/src/fmm/tree.rs
+++ b/kifmm/src/fmm/tree.rs
@@ -1,5 +1,4 @@
 //! Implementation of FmmTree Trait
-use rlst::RlstScalar;
 
 use super::types::SingleNodeFmmTree;
 use crate::traits::tree::{FmmTree, Tree};
@@ -8,12 +7,11 @@ use crate::RlstScalarFloat;
 
 impl<T> FmmTree for SingleNodeFmmTree<T>
 where
-    T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat,
+    T: RlstScalarFloat<Real = T>,
 {
     type Scalar = T;
     type Node = MortonKey<T::Real>;
-    type Tree = SingleNodeTree<T>;
+    type Tree = SingleNodeTree<T::Real>;
 
     fn source_tree(&self) -> &Self::Tree {
         &self.source_tree

--- a/kifmm/src/fmm/tree.rs
+++ b/kifmm/src/fmm/tree.rs
@@ -9,7 +9,7 @@ use crate::RlstScalarFloat;
 impl<T> FmmTree for SingleNodeFmmTree<T>
 where
     T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat
+    <T as RlstScalar>::Real: RlstScalarFloat,
 {
     type Scalar = T;
     type Node = MortonKey<T::Real>;

--- a/kifmm/src/fmm/tree.rs
+++ b/kifmm/src/fmm/tree.rs
@@ -10,7 +10,7 @@ where
     T: RlstScalar<Real = T> + Float + Default,
 {
     type Scalar = T;
-    type Node = MortonKey;
+    type Node = MortonKey<T>;
     type Tree = SingleNodeTree<T>;
 
     fn source_tree(&self) -> &Self::Tree {

--- a/kifmm/src/fmm/tree.rs
+++ b/kifmm/src/fmm/tree.rs
@@ -2,12 +2,13 @@
 use super::types::SingleNodeFmmTree;
 use crate::traits::tree::{FmmTree, Tree};
 use crate::tree::types::{MortonKey, SingleNodeTree};
-use num::Float;
-use rlst::RlstScalar;
+use crate::RlstScalarFloat;
+
+
 
 impl<T> FmmTree for SingleNodeFmmTree<T>
 where
-    T: RlstScalar<Real = T> + Float + Default,
+    T: RlstScalarFloat<Real = T>,
 {
     type Scalar = T;
     type Node = MortonKey<T>;
@@ -70,5 +71,5 @@ where
     }
 }
 
-unsafe impl<T: RlstScalar<Real = T> + Default + Float> Send for SingleNodeFmmTree<T> {}
-unsafe impl<T: RlstScalar<Real = T> + Default + Float> Sync for SingleNodeFmmTree<T> {}
+unsafe impl<T: RlstScalarFloat<Real = T>> Send for SingleNodeFmmTree<T> {}
+unsafe impl<T: RlstScalarFloat<Real = T>> Sync for SingleNodeFmmTree<T> {}

--- a/kifmm/src/fmm/types.rs
+++ b/kifmm/src/fmm/types.rs
@@ -1,7 +1,7 @@
 //! Data structures for kernel independent FMM
 use crate::traits::{field::SourceToTargetData, tree::FmmTree};
 use crate::tree::types::{Domain, MortonKey, SingleNodeTree};
-use crate::RlstScalarFloat;
+use crate::{RlstScalarComplexFloat, RlstScalarFloat};
 use green_kernels::{traits::Kernel, types::EvalType};
 use num::Complex;
 use num_complex::ComplexFloat;
@@ -161,7 +161,7 @@ where
     U: SourceToTargetData,
     V: Kernel,
     W: RlstScalarFloat,
-    <W as RlstScalar>::Real: RlstScalarFloat
+    <W as RlstScalar>::Real: RlstScalarFloat,
 {
     /// Dimension of the FMM
     pub dim: usize,
@@ -425,7 +425,7 @@ where
 pub struct SingleNodeFmmTree<T>
 where
     T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat
+    <T as RlstScalar>::Real: RlstScalarFloat,
 {
     /// An octree structure containing the source points for the FMM calculation.
     pub source_tree: SingleNodeTree<T>,
@@ -484,7 +484,7 @@ pub struct FftFieldTranslation<T, U>
 where
     T: RlstScalarFloat<Real = T>,
     U: Kernel<T = T> + Default,
-    Complex<T>: ComplexFloat,
+    Complex<T>: RlstScalarComplexFloat,
 {
     /// Map between indices of surface convolution grid points.
     pub surf_to_conv_map: Vec<usize>,

--- a/kifmm/src/fmm/types.rs
+++ b/kifmm/src/fmm/types.rs
@@ -250,10 +250,10 @@ pub struct KiFmm<
     pub level_locals: Vec<Vec<Vec<SendPtrMut<W>>>>,
 
     /// Index pointers to each key at a given level, indexed by level.
-    pub level_index_pointer_locals: Vec<HashMap<MortonKey, usize>>,
+    pub level_index_pointer_locals: Vec<HashMap<MortonKey<W>, usize>>,
 
     /// Index pointers to each key at a given level, indexed by level.
-    pub level_index_pointer_multipoles: Vec<HashMap<MortonKey, usize>>,
+    pub level_index_pointer_multipoles: Vec<HashMap<MortonKey<W>, usize>>,
 
     /// The evaluated potentials at each target leaf box.
     pub potentials_send_pointers: Vec<SendPtrMut<W>>,
@@ -487,7 +487,7 @@ where
     pub metadata: FftMetadata<Complex<T>>,
 
     /// Unique transfer vectors to lookup m2l unique kernel interactions
-    pub transfer_vectors: Vec<TransferVector>,
+    pub transfer_vectors: Vec<TransferVector<T>>,
 
     /// The associated kernel with this translation operator.
     pub kernel: U,
@@ -531,7 +531,7 @@ where
     pub metadata: BlasMetadata<T>,
 
     /// Unique transfer vectors corresponding to each metadata
-    pub transfer_vectors: Vec<TransferVector>,
+    pub transfer_vectors: Vec<TransferVector<T>>,
 
     /// The associated kernel with this translation operator.
     pub kernel: U,
@@ -560,7 +560,7 @@ where
 ///
 /// - `target`- The Morton key of the target box.
 #[derive(Debug)]
-pub struct TransferVector {
+pub struct TransferVector<T> {
     /// Three vector of components.
     pub components: [i64; 3],
 
@@ -568,10 +568,10 @@ pub struct TransferVector {
     pub hash: usize,
 
     /// The `source` Morton key associated with this transfer vector.
-    pub source: MortonKey,
+    pub source: MortonKey<T>,
 
     /// The `target` Morton key associated with this transfer vector.
-    pub target: MortonKey,
+    pub target: MortonKey<T>,
 }
 
 /// Stores metadata for FFT based acceleration scheme for field translation.

--- a/kifmm/src/fmm/types.rs
+++ b/kifmm/src/fmm/types.rs
@@ -537,7 +537,7 @@ where
     pub metadata: BlasMetadata<T>,
 
     /// Unique transfer vectors corresponding to each metadata
-    pub transfer_vectors: Vec<TransferVector<T>>,
+    pub transfer_vectors: Vec<TransferVector<T::Real>>,
 
     /// The associated kernel with this translation operator.
     pub kernel: U,
@@ -568,8 +568,7 @@ where
 #[derive(Debug)]
 pub struct TransferVector<T>
 where
-    T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat,
+    T: RlstScalarFloat<Real = T>,
 {
     /// Three vector of components.
     pub components: [i64; 3],
@@ -578,10 +577,10 @@ where
     pub hash: usize,
 
     /// The `source` Morton key associated with this transfer vector.
-    pub source: MortonKey<T::Real>,
+    pub source: MortonKey<T>,
 
     /// The `target` Morton key associated with this transfer vector.
-    pub target: MortonKey<T::Real>,
+    pub target: MortonKey<T>,
 }
 
 /// Stores metadata for FFT based acceleration scheme for field translation.
@@ -604,7 +603,7 @@ where
 #[derive(Default)]
 pub struct FftMetadata<T>
 where
-    T: ComplexFloat,
+    T: RlstScalarComplexFloat,
 {
     /// DFT of unique kernel evaluations for each source cluster in a halo of a target cluster
     pub kernel_data: Vec<Vec<T>>,

--- a/kifmm/src/fmm/types.rs
+++ b/kifmm/src/fmm/types.rs
@@ -1,14 +1,17 @@
 //! Data structures for kernel independent FMM
 use crate::traits::{field::SourceToTargetData, tree::FmmTree};
 use crate::tree::types::{Domain, MortonKey, SingleNodeTree};
+use crate::RlstScalarFloat;
 use green_kernels::{traits::Kernel, types::EvalType};
-use num::{Complex, Float};
+use num::Complex;
 use num_complex::ComplexFloat;
-use rlst::{rlst_dynamic_array2, Array, BaseArray, RlstScalar, VectorContainer};
+use rlst::{rlst_dynamic_array2, Array, BaseArray, VectorContainer};
 use std::collections::HashMap;
 
 #[cfg(feature = "mpi")]
 use crate::tree::types::MultiNodeTree;
+#[cfg(feature = "mpi")]
+use crate::RlstScalarFloatMpi;
 
 /// Represents charge data in a two-dimensional array with shape `[ncharges, nvecs]`,
 /// organized in column-major order.
@@ -156,7 +159,7 @@ pub struct KiFmm<
     T: FmmTree<Tree = SingleNodeTree<W>>,
     U: SourceToTargetData,
     V: Kernel,
-    W: RlstScalar<Real = W> + Float + Default,
+    W: RlstScalarFloat<Real = W>,
 > {
     /// Dimension of the FMM
     pub dim: usize,
@@ -369,7 +372,7 @@ pub enum FmmEvalType {
 pub struct SingleNodeBuilder<T, U, V>
 where
     T: SourceToTargetData,
-    U: RlstScalar<Real = U> + Float + Default,
+    U: RlstScalarFloat<Real = U>,
     V: Kernel,
 {
     /// Tree
@@ -417,7 +420,7 @@ where
 ///   defines the spatial extent within which the sources and targets are located and
 ///   interacts.
 #[derive(Default)]
-pub struct SingleNodeFmmTree<T: RlstScalar<Real = T> + Float + Default> {
+pub struct SingleNodeFmmTree<T: RlstScalarFloat<Real = T>> {
     /// An octree structure containing the source points for the FMM calculation.
     pub source_tree: SingleNodeTree<T>,
     /// An octree structure containing the target points for the FMM calculation.
@@ -443,7 +446,7 @@ pub struct SingleNodeFmmTree<T: RlstScalar<Real = T> + Float + Default> {
 ///   defines the spatial extent within which the sources and targets are located and
 ///   interacts.
 #[cfg(feature = "mpi")]
-pub struct MultiNodeFmmTree<T: RlstScalar<Real = T> + Float + Default> {
+pub struct MultiNodeFmmTree<T: RlstScalarFloatMpi<Real = T>> {
     /// An octree structure containing the source points for the FMM calculation.
     pub source_tree: MultiNodeTree<T>,
     /// An octree structure containing the target points for the FMM calculation.
@@ -473,7 +476,7 @@ pub struct MultiNodeFmmTree<T: RlstScalar<Real = T> + Float + Default> {
 #[derive(Default)]
 pub struct FftFieldTranslation<T, U>
 where
-    T: Default + RlstScalar<Real = T> + Float,
+    T: RlstScalarFloat<Real = T>,
     U: Kernel<T = T> + Default,
     Complex<T>: ComplexFloat,
 {
@@ -521,7 +524,7 @@ where
 #[derive(Default)]
 pub struct BlasFieldTranslation<T, U>
 where
-    T: RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
     U: Kernel<T = T> + Default,
 {
     /// Threshold
@@ -654,7 +657,7 @@ where
 /// - `c_vt`- Right singular vectors of re-compressed M2L matrix, one entry for each transfer vector.
 pub struct BlasMetadata<T>
 where
-    T: RlstScalar,
+    T: RlstScalarFloat,
 {
     /// Left singular vectors from SVD of fat M2L matrix, truncated to a maximum cutoff rank
     pub u: Array<T, BaseArray<T, VectorContainer<T>, 2>, 2>,
@@ -671,7 +674,7 @@ where
 
 impl<T> Default for BlasMetadata<T>
 where
-    T: RlstScalar,
+    T: RlstScalarFloat,
 {
     fn default() -> Self {
         let u = rlst_dynamic_array2!(T, [1, 1]);

--- a/kifmm/src/fmm/types.rs
+++ b/kifmm/src/fmm/types.rs
@@ -157,7 +157,7 @@ pub struct SendPtr<T> {
 ///
 pub struct KiFmm<T, U, V, W>
 where
-    T: FmmTree<Tree = SingleNodeTree<W>>,
+    T: FmmTree<Tree = SingleNodeTree<W::Real>>,
     U: SourceToTargetData,
     V: Kernel,
     W: RlstScalarFloat,
@@ -428,9 +428,9 @@ where
     <T as RlstScalar>::Real: RlstScalarFloat,
 {
     /// An octree structure containing the source points for the FMM calculation.
-    pub source_tree: SingleNodeTree<T>,
+    pub source_tree: SingleNodeTree<T::Real>,
     /// An octree structure containing the target points for the FMM calculation.
-    pub target_tree: SingleNodeTree<T>,
+    pub target_tree: SingleNodeTree<T::Real>,
     /// The computational domain associated with this FMM calculation.
     pub domain: Domain<T::Real>,
 }

--- a/kifmm/src/fmm/types.rs
+++ b/kifmm/src/fmm/types.rs
@@ -4,7 +4,6 @@ use crate::tree::types::{Domain, MortonKey, SingleNodeTree};
 use crate::{RlstScalarComplexFloat, RlstScalarFloat};
 use green_kernels::{traits::Kernel, types::EvalType};
 use num::Complex;
-use num_complex::ComplexFloat;
 use rlst::{rlst_dynamic_array2, Array, BaseArray, RlstScalar, VectorContainer};
 use std::collections::HashMap;
 
@@ -478,7 +477,8 @@ pub struct MultiNodeFmmTree<T: RlstScalarFloatMpi<Real = T>> {
 #[derive(Default)]
 pub struct FftFieldTranslation<T, U>
 where
-    T: RlstScalarFloat<Real = T>,
+    T: RlstScalarFloat,
+    <T as RlstScalar>::Real: RlstScalarFloat,
     U: Kernel<T = T> + Default,
     Complex<T>: RlstScalarComplexFloat,
 {
@@ -492,7 +492,7 @@ where
     pub metadata: FftMetadata<Complex<T>>,
 
     /// Unique transfer vectors to lookup m2l unique kernel interactions
-    pub transfer_vectors: Vec<TransferVector<T>>,
+    pub transfer_vectors: Vec<TransferVector<T::Real>>,
 
     /// The associated kernel with this translation operator.
     pub kernel: U,

--- a/kifmm/src/fmm/types.rs
+++ b/kifmm/src/fmm/types.rs
@@ -422,17 +422,13 @@ where
 ///   defines the spatial extent within which the sources and targets are located and
 ///   interacts.
 #[derive(Default)]
-pub struct SingleNodeFmmTree<T>
-where
-    T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat,
-{
+pub struct SingleNodeFmmTree<T: RlstScalarFloat<Real = T>> {
     /// An octree structure containing the source points for the FMM calculation.
-    pub source_tree: SingleNodeTree<T::Real>,
+    pub source_tree: SingleNodeTree<T>,
     /// An octree structure containing the target points for the FMM calculation.
-    pub target_tree: SingleNodeTree<T::Real>,
+    pub target_tree: SingleNodeTree<T>,
     /// The computational domain associated with this FMM calculation.
-    pub domain: Domain<T::Real>,
+    pub domain: Domain<T>,
 }
 
 /// Represents an octree structure for Fast Multipole Method (FMM) calculations on distributed nodes.

--- a/kifmm/src/lib.rs
+++ b/kifmm/src/lib.rs
@@ -108,15 +108,20 @@ use rlst::{c32, c64};
 #[doc(inline)]
 pub use traits::fmm::Fmm;
 
-/// Super trait of RlstScalar and num_traits Float trait
+/// Super trait of RlstScalar and  Float trait
 pub trait RlstScalarFloat: RlstScalar + Float + Default {}
 
 /// Super trait of RlstScalar and Complex Float trait
 pub trait RlstScalarComplexFloat: RlstScalar + ComplexFloat + Default {}
 
 #[cfg(feature = "mpi")]
-/// Combination of RlstScalar and num_traits Float trait, with a equivalent MPI type
+/// Super trait of RlstScalar and Float trait, and MPI Equivalence trait
 pub trait RlstScalarFloatMpi: RlstScalarFloat + Equivalence {}
+
+#[cfg(feature = "mpi")]
+/// Super trait of RlstScalar and Complex Float trait, and MPI Equivalence trait
+pub trait RlstScalarComplexFloatMpi: RlstScalarFloatMpi + Equivalence {}
+
 
 impl RlstScalarFloat for f64 {}
 impl RlstScalarFloat for f32 {}

--- a/kifmm/src/lib.rs
+++ b/kifmm/src/lib.rs
@@ -122,7 +122,6 @@ pub trait RlstScalarFloatMpi: RlstScalarFloat + Equivalence {}
 /// Super trait of RlstScalar and Complex Float trait, and MPI Equivalence trait
 pub trait RlstScalarComplexFloatMpi: RlstScalarFloatMpi + Equivalence {}
 
-
 impl RlstScalarFloat for f64 {}
 impl RlstScalarFloat for f32 {}
 

--- a/kifmm/src/lib.rs
+++ b/kifmm/src/lib.rs
@@ -98,5 +98,34 @@ pub use fmm::types::SingleNodeFmmTree;
 #[doc(inline)]
 pub use fmm::types::MultiNodeFmmTree;
 
+#[cfg(feature="mpi")]
+use mpi::traits::Equivalence;
+
+use num::Float;
+use num_complex::ComplexFloat;
+use rlst::{c32, c64};
+use rlst::RlstScalar;
 #[doc(inline)]
 pub use traits::fmm::Fmm;
+
+/// Super trait of RlstScalar and num_traits Float trait
+pub trait RlstScalarFloat: RlstScalar + Float + Default {}
+
+
+/// Super trait of RlstScalar and Complex Float trait
+pub trait RlstScalarComplexFloat: RlstScalar + ComplexFloat + Default {}
+
+#[cfg(feature="mpi")]
+/// Combination of RlstScalar and num_traits Float trait, with a equivalent MPI type
+pub trait RlstScalarFloatMpi: RlstScalarFloat + Equivalence {}
+
+impl RlstScalarFloat for f64 {}
+impl RlstScalarFloat for f32 {}
+
+#[cfg(feature="mpi")]
+impl RlstScalarFloatMpi for f64 {}
+#[cfg(feature="mpi")]
+impl RlstScalarFloatMpi for f32 {}
+
+impl RlstScalarComplexFloat for c64 {}
+impl RlstScalarComplexFloat for c32 {}

--- a/kifmm/src/lib.rs
+++ b/kifmm/src/lib.rs
@@ -98,33 +98,32 @@ pub use fmm::types::SingleNodeFmmTree;
 #[doc(inline)]
 pub use fmm::types::MultiNodeFmmTree;
 
-#[cfg(feature="mpi")]
+#[cfg(feature = "mpi")]
 use mpi::traits::Equivalence;
 
 use num::Float;
 use num_complex::ComplexFloat;
-use rlst::{c32, c64};
 use rlst::RlstScalar;
+use rlst::{c32, c64};
 #[doc(inline)]
 pub use traits::fmm::Fmm;
 
 /// Super trait of RlstScalar and num_traits Float trait
 pub trait RlstScalarFloat: RlstScalar + Float + Default {}
 
-
 /// Super trait of RlstScalar and Complex Float trait
 pub trait RlstScalarComplexFloat: RlstScalar + ComplexFloat + Default {}
 
-#[cfg(feature="mpi")]
+#[cfg(feature = "mpi")]
 /// Combination of RlstScalar and num_traits Float trait, with a equivalent MPI type
 pub trait RlstScalarFloatMpi: RlstScalarFloat + Equivalence {}
 
 impl RlstScalarFloat for f64 {}
 impl RlstScalarFloat for f32 {}
 
-#[cfg(feature="mpi")]
+#[cfg(feature = "mpi")]
 impl RlstScalarFloatMpi for f64 {}
-#[cfg(feature="mpi")]
+#[cfg(feature = "mpi")]
 impl RlstScalarFloatMpi for f32 {}
 
 impl RlstScalarComplexFloat for c64 {}

--- a/kifmm/src/traits/field.rs
+++ b/kifmm/src/traits/field.rs
@@ -1,5 +1,6 @@
 //! Field Traits
 use green_kernels::traits::Kernel;
+use rlst::RlstScalar;
 
 use crate::RlstScalarFloat;
 
@@ -17,12 +18,13 @@ pub trait ConfigureSourceToTargetData<T>
 where
     Self: SourceToTargetData,
     T: RlstScalarFloat,
+    <T as RlstScalar>::Real: RlstScalarFloat,
 {
     /// Kernel function associated with field translation
     type Kernel: Kernel;
 
     /// The computational domain defining the tree.
-    type Domain: Domain<T>;
+    type Domain: Domain<T::Real>;
 
     /// Set the field translation operators corresponding to each unique transfer vector.
     ///

--- a/kifmm/src/traits/field.rs
+++ b/kifmm/src/traits/field.rs
@@ -1,6 +1,8 @@
 //! Field Traits
 use green_kernels::traits::Kernel;
 
+use crate::RlstScalarFloat;
+
 use super::tree::Domain;
 
 /// Marker trait for field translations
@@ -11,15 +13,16 @@ pub trait SourceToTargetData {
 }
 
 /// Interface for configuration of field translation data used during FMM construction
-pub trait ConfigureSourceToTargetData
+pub trait ConfigureSourceToTargetData<T>
 where
     Self: SourceToTargetData,
+    T: RlstScalarFloat,
 {
     /// Kernel function associated with field translation
     type Kernel: Kernel;
 
     /// The computational domain defining the tree.
-    type Domain: Domain;
+    type Domain: Domain<T>;
 
     /// Set the field translation operators corresponding to each unique transfer vector.
     ///

--- a/kifmm/src/traits/fmm.rs
+++ b/kifmm/src/traits/fmm.rs
@@ -1,5 +1,5 @@
 //! FMM traits
-use crate::{fmm::types::Charges, traits::tree::FmmTree};
+use crate::{fmm::types::Charges, traits::tree::FmmTree, RlstScalarFloat};
 use green_kernels::traits::Kernel;
 use rlst::RlstScalar;
 
@@ -60,15 +60,18 @@ pub trait SourceToTargetTranslation {
 /// data structures, kernels, and precision types. It supports operations essential for
 /// executing FMM calculations, including accessing multipole and local expansions, evaluating
 /// potentials, and managing the underlying tree structure and kernel functions.
-pub trait Fmm {
+pub trait Fmm
+where
+    <Self::Scalar as RlstScalar>::Real: RlstScalarFloat
+{
     /// Data associated with FMM, must implement RlstScalar.
-    type Scalar: RlstScalar;
+    type Scalar: RlstScalarFloat;
 
     /// Node index for accessing data in the tree.
     type Node;
 
     /// Type of tree, must implement `FmmTree`, allowing for separate source and target trees.
-    type Tree: FmmTree;
+    type Tree: FmmTree<Scalar = Self::Scalar>;
 
     /// Kernel associated with this FMMl
     type Kernel: Kernel;

--- a/kifmm/src/traits/fmm.rs
+++ b/kifmm/src/traits/fmm.rs
@@ -62,7 +62,7 @@ pub trait SourceToTargetTranslation {
 /// potentials, and managing the underlying tree structure and kernel functions.
 pub trait Fmm
 where
-    <Self::Scalar as RlstScalar>::Real: RlstScalarFloat
+    <Self::Scalar as RlstScalar>::Real: RlstScalarFloat,
 {
     /// Data associated with FMM, must implement RlstScalar.
     type Scalar: RlstScalarFloat;

--- a/kifmm/src/traits/tree.rs
+++ b/kifmm/src/traits/tree.rs
@@ -1,16 +1,17 @@
 //! Tree Traits
 use std::{collections::HashSet, hash::Hash};
 
-use num::Float;
 use rlst::RlstScalar;
+
+use crate::RlstScalarFloat;
 
 /// Interface for single and multi-node trees
 pub trait Tree {
-    /// The computational domain defining the tree.
-    type Domain: Domain;
-
     /// Scalar type
-    type Scalar: RlstScalar<Real = Self::Scalar> + Float + Default;
+    type Scalar: RlstScalarFloat;
+
+    /// The computational domain defining the tree.
+    type Domain: Domain<Self::Scalar>;
 
     /// A tree node.
     type Node: TreeNode<Self::Scalar, Domain = Self::Domain> + Clone + Copy;
@@ -54,7 +55,7 @@ pub trait Tree {
     ///
     /// # arguments
     /// - `leaf` - node being query.
-    fn coordinates(&self, leaf: &Self::Node) -> Option<&[Self::Scalar]>;
+    fn coordinates(&self, leaf: &Self::Node) -> Option<&[<Self::Scalar as RlstScalar>::Real]>;
 
     /// Query number of coordinates contained at a given leaf node
     ///
@@ -63,7 +64,7 @@ pub trait Tree {
     fn n_coordinates(&self, leaf: &Self::Node) -> Option<usize>;
 
     /// Gets a reference to the coordinates contained in across tree (local in multi node setting)
-    fn all_coordinates(&self) -> Option<&[Self::Scalar]>;
+    fn all_coordinates(&self) -> Option<&[<Self::Scalar as RlstScalar>::Real]>;
 
     /// Total number of coordinates (local in a multi node setting)
     fn n_coordinates_tot(&self) -> Option<usize>;
@@ -127,10 +128,10 @@ pub trait FmmTree {
 pub trait TreeNode<T>
 where
     Self: Hash + Eq,
-    T: RlstScalar,
+    T: RlstScalarFloat,
 {
     /// The computational domain defining the tree.
-    type Domain: Domain;
+    type Domain: Domain<T>;
 
     /// Copy of nodes
     type Nodes: IntoIterator<Item = Self>;
@@ -158,7 +159,7 @@ where
 pub trait FmmTreeNode<T>
 where
     Self: TreeNode<T>,
-    T: RlstScalar,
+    T: RlstScalarFloat,
 {
     /// Scale a surface centered at this node, used in the discretisation of the kernel independent fast nultipole
     /// method
@@ -205,13 +206,13 @@ where
 }
 
 /// Interface for computational domain
-pub trait Domain {
-    /// Scalar type
-    type Scalar: RlstScalar;
-
+pub trait Domain<T>
+where
+    T: RlstScalarFloat,
+{
     /// Origin of computational domain.
-    fn origin(&self) -> &[Self::Scalar; 3];
+    fn origin(&self) -> &[T::Real; 3];
 
     /// Side length along each axis
-    fn diameter(&self) -> &[Self::Scalar; 3];
+    fn diameter(&self) -> &[T::Real; 3];
 }

--- a/kifmm/src/tree.rs
+++ b/kifmm/src/tree.rs
@@ -19,7 +19,7 @@
 //! let depth = 3; // The depth of the tree
 //!
 //! // Create a single node tree
-//! let single_node = SingleNodeTree::new(
+//! let single_node = SingleNodeTree::<f32>::new(
 //!     points.data(),
 //!     depth,
 //!     sparse,

--- a/kifmm/src/tree/constants.rs
+++ b/kifmm/src/tree/constants.rs
@@ -1,18 +1,10 @@
 //! Module wide constants.
 
-use crate::tree::types::MortonKey;
-
 /// Maximum possible level of octree recursion, by definition.
 pub const DEEPEST_LEVEL: u64 = 16;
 
 /// The 'size' of each level in terms of octants along each axis, at the maximum depth of recursion.
 pub const LEVEL_SIZE: u64 = 65536;
-
-/// The root node of any octree.
-pub const ROOT: MortonKey = MortonKey {
-    anchor: [0, 0, 0],
-    morton: 0,
-};
 
 /// Transfer vectors in component form to nearest octant neighbours, in Morton order.
 pub const DIRECTIONS: [[i64; 3]; 26] = [

--- a/kifmm/src/tree/domain.rs
+++ b/kifmm/src/tree/domain.rs
@@ -93,16 +93,16 @@ where
     }
 }
 
-impl<T> DomainTrait<T> for Domain<T::Real>
+impl<T> DomainTrait<T> for Domain<T>
 where
-    T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat,
+    T: RlstScalarFloat<Real = T>,
+    // <T as RlstScalar>::Real: RlstScalarFloat,
 {
-    fn diameter(&self) -> &[T::Real; 3] {
+    fn diameter(&self) -> &[T; 3] {
         &self.side_length
     }
 
-    fn origin(&self) -> &[T::Real; 3] {
+    fn origin(&self) -> &[T; 3] {
         &self.origin
     }
 }
@@ -211,7 +211,6 @@ mod mpi_domain {
 #[cfg(feature = "mpi")]
 pub use mpi_domain::*;
 use num::Float;
-use rlst::RlstScalar;
 
 #[cfg(test)]
 mod test {

--- a/kifmm/src/tree/domain.rs
+++ b/kifmm/src/tree/domain.rs
@@ -84,10 +84,10 @@ impl<T: Float + Default + Debug> Domain<T> {
     /// # Arguments
     /// * `origin` - The point from which to construct a cuboid domain.
     /// * `diameter` - The diameter along each axis of the domain.
-    pub fn new(origin: &[T; 3], diameter: &[T; 3]) -> Self {
+    pub fn new(origin: &[T; 3], side_length: &[T; 3]) -> Self {
         Domain {
             origin: *origin,
-            side_length: *diameter,
+            side_length: *side_length,
         }
     }
 }

--- a/kifmm/src/tree/domain.rs
+++ b/kifmm/src/tree/domain.rs
@@ -89,7 +89,7 @@ impl<T: RlstScalarFloat> Domain<T> {
     }
 }
 
-impl<T: RlstScalarFloat > DomainTrait for Domain<T> {
+impl<T: RlstScalarFloat> DomainTrait for Domain<T> {
     type Scalar = T;
 
     fn diameter(&self) -> &[Self::Scalar; 3] {
@@ -203,7 +203,6 @@ mod mpi_domain {
 pub use mpi_domain::*;
 use num::Float;
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -212,7 +211,7 @@ mod test {
 
     fn test_compute_bounds<T>(points: PointsMat<T>)
     where
-        T:  RlstScalarFloat,
+        T: RlstScalarFloat,
     {
         let domain = Domain::from_local_points(points.data());
 

--- a/kifmm/src/tree/morton.rs
+++ b/kifmm/src/tree/morton.rs
@@ -12,6 +12,7 @@ use crate::tree::{
 use itertools::{izip, Itertools};
 use num::{Float, ToPrimitive};
 use rlst::RlstScalar;
+use std::marker::PhantomData;
 use std::{
     cmp::Ordering,
     collections::HashSet,
@@ -30,12 +31,12 @@ use std::{
 /// # Arguments
 ///
 /// - `keys` -, A slice of Morton Keys subject to linearization, ensuring uniqueness and non-overlap in the resulting set.
-fn linearize_keys(keys: &[MortonKey]) -> Vec<MortonKey> {
+fn linearize_keys<T: Debug + Default + Float>(keys: &[MortonKey<T>]) -> Vec<MortonKey<T>> {
     let depth = keys.iter().map(|k| k.level()).max().unwrap();
-    let mut key_set: HashSet<MortonKey> = keys.iter().cloned().collect();
+    let mut key_set: HashSet<MortonKey<_>> = keys.iter().cloned().collect();
 
     for level in (0..=depth).rev() {
-        let work_set: Vec<&MortonKey> = keys.iter().filter(|&&k| k.level() == level).collect();
+        let work_set: Vec<&MortonKey<_>> = keys.iter().filter(|&&k| k.level() == level).collect();
 
         for work_item in work_set.iter() {
             let mut ancestors = work_item.ancestors();
@@ -48,7 +49,7 @@ fn linearize_keys(keys: &[MortonKey]) -> Vec<MortonKey> {
         }
     }
 
-    let result: Vec<MortonKey> = key_set.into_iter().collect();
+    let result: Vec<MortonKey<_>> = key_set.into_iter().collect();
     result
 }
 
@@ -64,8 +65,10 @@ fn linearize_keys(keys: &[MortonKey]) -> Vec<MortonKey> {
 ///
 /// - `keys` - A slice of Morton Keys to enforce the 2:1 balance upon. The keys should represent a
 /// contiguous space without gaps.
-fn balance_keys(keys: &[MortonKey]) -> HashSet<MortonKey> {
-    let mut balanced: HashSet<MortonKey> = keys.iter().cloned().collect();
+fn balance_keys<T: Clone + Float + Default + Debug>(
+    keys: &[MortonKey<T>],
+) -> HashSet<MortonKey<T>> {
+    let mut balanced: HashSet<MortonKey<_>> = keys.iter().cloned().collect();
     let deepest_level = keys.iter().map(|key| key.level()).max().unwrap();
 
     for level in (0..=deepest_level).rev() {
@@ -104,16 +107,20 @@ fn balance_keys(keys: &[MortonKey]) -> HashSet<MortonKey> {
 ///
 /// - `start` - The Morton Key defining the beginning of the region to complete.
 /// - `end` - The Morton Key marking the end of the region.
-pub fn complete_region(start: &MortonKey, end: &MortonKey) -> Vec<MortonKey> {
-    let mut start_ancestors: HashSet<MortonKey> = start.ancestors();
-    let mut end_ancestors: HashSet<MortonKey> = end.ancestors();
+pub fn complete_region<T: Debug + Default + Float>(
+    start: &MortonKey<T>,
+    end: &MortonKey<T>,
+) -> Vec<MortonKey<T>> {
+    let mut start_ancestors: HashSet<MortonKey<_>> = start.ancestors();
+    let mut end_ancestors: HashSet<MortonKey<_>> = end.ancestors();
 
     // Remove endpoints from ancestors
     start_ancestors.remove(start);
     end_ancestors.remove(end);
 
-    let mut minimal_tree: Vec<MortonKey> = Vec::new();
-    let mut work_list: Vec<MortonKey> = start.finest_ancestor(end).children().into_iter().collect();
+    let mut minimal_tree: Vec<MortonKey<_>> = Vec::new();
+    let mut work_list: Vec<MortonKey<_>> =
+        start.finest_ancestor(end).children().into_iter().collect();
 
     while let Some(current_item) = work_list.pop() {
         if (current_item > *start) & (current_item < *end) & !end_ancestors.contains(&current_item)
@@ -132,9 +139,9 @@ pub fn complete_region(start: &MortonKey, end: &MortonKey) -> Vec<MortonKey> {
     minimal_tree
 }
 
-impl MortonKeys {
+impl<T: Debug + Default + Float> MortonKeys<T> {
     /// Create new
-    pub fn new() -> MortonKeys {
+    pub fn new() -> MortonKeys<T> {
         MortonKeys {
             keys: Vec::new(),
             index: 0,
@@ -142,7 +149,7 @@ impl MortonKeys {
     }
 
     /// Add a key
-    pub fn add(&mut self, item: MortonKey) {
+    pub fn add(&mut self, item: MortonKey<T>) {
         self.keys.push(item);
     }
 
@@ -177,22 +184,22 @@ impl MortonKeys {
     }
 }
 
-impl Deref for MortonKeys {
-    type Target = Vec<MortonKey>;
+impl<T> Deref for MortonKeys<T> {
+    type Target = Vec<MortonKey<T>>;
 
     fn deref(&self) -> &Self::Target {
         &self.keys
     }
 }
 
-impl DerefMut for MortonKeys {
+impl<T> DerefMut for MortonKeys<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.keys
     }
 }
 
-impl Iterator for MortonKeys {
-    type Item = MortonKey;
+impl<T: Copy> Iterator for MortonKeys<T> {
+    type Item = MortonKey<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.index >= self.keys.len() {
@@ -204,8 +211,8 @@ impl Iterator for MortonKeys {
     }
 }
 
-impl FromIterator<MortonKey> for MortonKeys {
-    fn from_iter<I: IntoIterator<Item = MortonKey>>(iter: I) -> Self {
+impl<T: Debug + Default + Float> FromIterator<MortonKey<T>> for MortonKeys<T> {
+    fn from_iter<I: IntoIterator<Item = MortonKey<T>>>(iter: I) -> Self {
         let mut c = MortonKeys::new();
 
         for i in iter {
@@ -215,18 +222,43 @@ impl FromIterator<MortonKey> for MortonKeys {
     }
 }
 
-impl From<Vec<MortonKey>> for MortonKeys {
-    fn from(keys: Vec<MortonKey>) -> Self {
+impl<T> From<Vec<MortonKey<T>>> for MortonKeys<T> {
+    fn from(keys: Vec<MortonKey<T>>) -> Self {
         MortonKeys { keys, index: 0 }
     }
 }
 
-impl From<HashSet<MortonKey>> for MortonKeys {
-    fn from(keys: HashSet<MortonKey>) -> Self {
+impl<T> From<HashSet<MortonKey<T>>> for MortonKeys<T> {
+    fn from(keys: HashSet<MortonKey<T>>) -> Self {
         MortonKeys {
             keys: keys.into_iter().collect_vec(),
             index: 0,
         }
+    }
+}
+
+impl<T> PartialEq for MortonKey<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.morton == other.morton
+    }
+}
+impl<T> Eq for MortonKey<T> {}
+
+impl<T> Ord for MortonKey<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.morton.cmp(&other.morton)
+    }
+}
+
+impl<T> PartialOrd for MortonKey<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.morton.cmp(&other.morton))
+    }
+}
+
+impl<T> Hash for MortonKey<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.morton.hash(state);
     }
 }
 
@@ -330,21 +362,44 @@ pub fn encode_anchor(anchor: &[u64; 3], level: u64) -> u64 {
     key | level
 }
 
-impl MortonKey {
+impl<T: Float + Default + Debug> MortonKey<T> {
+    /// Constructor for Morton key
+    pub fn new(anchor: &[u64; 3], morton: u64) -> Self {
+        Self {
+            anchor: *anchor,
+            morton,
+            scalar: PhantomData::<T>::default(),
+        }
+    }
+
+    /// The Morton key corresponding to an octree root node
+    pub fn root() -> Self {
+        Self {
+            anchor: [0, 0, 0],
+            morton: 1,
+            ..Default::default()
+        }
+    }
+
     /// Construct a `MortonKey` type from a Morton index
     pub fn from_morton(morton: u64) -> Self {
         let anchor = decode_key(morton);
 
-        MortonKey { anchor, morton }
+        Self {
+            anchor,
+            morton,
+            ..Default::default()
+        }
     }
 
     /// Construct a `MortonKey` type from the anchor at a given level
     pub fn from_anchor(anchor: &[u64; 3], level: u64) -> Self {
         let morton = encode_anchor(anchor, level);
 
-        MortonKey {
+        Self {
             anchor: *anchor,
             morton,
+            ..Default::default()
         }
     }
 
@@ -354,11 +409,7 @@ impl MortonKey {
     /// * `point` - Cartesian coordinate for a given point.
     /// * `domain` - Domain associated with a given tree encoding.
     /// * `level` - level of octree on which to find the encoding.
-    pub fn from_point<T: Float + Default + Debug>(
-        point: &[T; 3],
-        domain: &Domain<T>,
-        level: u64,
-    ) -> Self {
+    pub fn from_point(point: &[T; 3], domain: &Domain<T>, level: u64) -> Self {
         let anchor = point_to_anchor(point, level, domain).unwrap();
         MortonKey::from_anchor(&anchor, level)
     }
@@ -369,7 +420,7 @@ impl MortonKey {
     /// * `other` - A Morton Key with which to calculate a transfer vector to.
     pub fn find_transfer_vector_components(
         &self,
-        &other: &MortonKey,
+        &other: &MortonKey<T>,
     ) -> Result<[i64; 3], std::io::Error> {
         // Only valid for keys at level 2 and below
         if self.level() < 2 || other.level() < 2 {
@@ -431,9 +482,9 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `other` - A Morton Key with which to calculate a transfer vector to.
-    pub fn find_transfer_vector(&self, &other: &MortonKey) -> Result<usize, std::io::Error> {
+    pub fn find_transfer_vector(&self, &other: &MortonKey<T>) -> Result<usize, std::io::Error> {
         let tmp = self.find_transfer_vector_components(&other)?;
-        Ok(MortonKey::find_transfer_vector_from_components(&tmp))
+        Ok(MortonKey::<T>::find_transfer_vector_from_components(&tmp))
     }
 
     /// The physical diameter of a box specified by this Morton Key, calculated with respect to
@@ -442,7 +493,7 @@ impl MortonKey {
     ///
     /// # Arguments
     /// `domain` - The physical domain with which we calculate the diameter with respect to.
-    pub fn diameter<T: Float + Default>(&self, domain: &Domain<T>) -> [T; 3] {
+    pub fn diameter(&self, domain: &Domain<T>) -> [T; 3] {
         domain
             .side_length
             .map(|x| T::from(0.5).unwrap().powf(T::from(self.level()).unwrap()) * x)
@@ -453,7 +504,7 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `domain` - The physical domain with which we calculate the centre with respect to.
-    pub fn centre<T: Float + Default>(&self, domain: &Domain<T>) -> [T; 3] {
+    pub fn centre(&self, domain: &Domain<T>) -> [T; 3] {
         let mut result = [T::zero(); 3];
 
         let anchor_coordinate = self.to_coordinates(domain);
@@ -503,6 +554,7 @@ impl MortonKey {
         MortonKey {
             anchor: self.anchor,
             morton: 1 + self.morton,
+            ..Default::default()
         }
     }
 
@@ -511,6 +563,7 @@ impl MortonKey {
         MortonKey {
             anchor: self.anchor,
             morton: DEEPEST_LEVEL - self.level() + self.morton,
+            ..Default::default()
         }
     }
 
@@ -537,12 +590,12 @@ impl MortonKey {
     }
 
     /// Return all children of a Morton Key in sorted order.
-    pub fn children(&self) -> Vec<MortonKey> {
+    pub fn children(&self) -> Vec<MortonKey<T>> {
         let level = self.level();
         let morton = self.morton() >> LEVEL_DISPLACEMENT;
 
         let mut children_morton: [u64; 8] = [0; 8];
-        let mut children: Vec<MortonKey> = Vec::with_capacity(8);
+        let mut children = Vec::with_capacity(8);
         let bit_shift = 3 * (DEEPEST_LEVEL - level - 1);
         for (index, item) in children_morton.iter_mut().enumerate() {
             *item = ((morton | (index << bit_shift) as u64) << LEVEL_DISPLACEMENT) | (level + 1);
@@ -557,24 +610,24 @@ impl MortonKey {
     }
 
     /// Return all children of the parent of this Morton Key.
-    pub fn siblings(&self) -> Vec<MortonKey> {
+    pub fn siblings(&self) -> Vec<MortonKey<T>> {
         self.parent().children()
     }
 
     /// Check if the key is ancestor of `other`.
-    pub fn is_ancestor(&self, other: &MortonKey) -> bool {
+    pub fn is_ancestor(&self, other: &MortonKey<T>) -> bool {
         let ancestors = other.ancestors();
         ancestors.contains(self)
     }
 
     /// Check if key is descendant of another key.
-    pub fn is_descendant(&self, other: &MortonKey) -> bool {
+    pub fn is_descendant(&self, other: &MortonKey<T>) -> bool {
         other.is_ancestor(self)
     }
 
     /// Return set of all ancestors of this Morton Key.
-    pub fn ancestors(&self) -> HashSet<MortonKey> {
-        let mut ancestors = HashSet::<MortonKey>::new();
+    pub fn ancestors(&self) -> HashSet<MortonKey<T>> {
+        let mut ancestors = HashSet::<MortonKey<_>>::new();
 
         let mut current = *self;
 
@@ -592,7 +645,7 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `n` - The level below the key's level to return descendants from.
-    pub fn descendants(&self, n: u64) -> Result<Vec<MortonKey>, std::io::Error> {
+    pub fn descendants(&self, n: u64) -> Result<Vec<MortonKey<T>>, std::io::Error> {
         let valid: bool = self.level() + n <= DEEPEST_LEVEL;
 
         match valid {
@@ -603,7 +656,7 @@ impl MortonKey {
             true => {
                 let mut descendants = vec![*self];
                 for _ in 0..n {
-                    let mut tmp = Vec::<MortonKey>::new();
+                    let mut tmp = Vec::<MortonKey<_>>::new();
                     for key in descendants {
                         tmp.append(&mut key.children());
                     }
@@ -618,7 +671,7 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `other` - The key with which we are calculating the shared finest ancestor with respect to.
-    pub fn finest_ancestor(&self, other: &MortonKey) -> MortonKey {
+    pub fn finest_ancestor(&self, other: &MortonKey<T>) -> MortonKey<T> {
         if self == other {
             *other
         } else {
@@ -635,7 +688,7 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `domain` - The domain with which we are calculating with respect to.
-    pub fn to_coordinates<T: Float + Default>(&self, domain: &Domain<T>) -> [T; 3] {
+    pub fn to_coordinates(&self, domain: &Domain<T>) -> [T; 3] {
         let mut coord: [T; 3] = [T::zero(); 3];
 
         for (anchor_value, coord_ref, origin_value, diameter_value) in
@@ -665,7 +718,7 @@ impl MortonKey {
     ///
     /// # Arguments
     /// * `domain` - The domain with which we are calculating with respect to.
-    pub fn box_coordinates<T: Float + Default>(&self, domain: &Domain<T>) -> Vec<T> {
+    pub fn box_coordinates(&self, domain: &Domain<T>) -> Vec<T> {
         let mut serialized = Vec::<T>::with_capacity(24);
         let level = self.level();
         let step = (1 << (DEEPEST_LEVEL - level)) as u64;
@@ -715,7 +768,7 @@ impl MortonKey {
     /// # Arguments
     /// * `direction` - A vector describing how many boxes we move along each coordinate direction.
     ///               Negative values are possible (meaning that we move backwards).
-    pub fn find_key_in_direction(&self, direction: &[i64; 3]) -> Option<MortonKey> {
+    pub fn find_key_in_direction(&self, direction: &[i64; 3]) -> Option<MortonKey<T>> {
         let level = self.level();
 
         let max_number_of_boxes: i64 = 1 << DEEPEST_LEVEL;
@@ -741,6 +794,7 @@ impl MortonKey {
             Some(MortonKey {
                 anchor: new_anchor,
                 morton: new_morton,
+                ..Default::default()
             })
         } else {
             None
@@ -748,7 +802,7 @@ impl MortonKey {
     }
 
     /// Find all neighbors for to a given key. Filter out 'invalid' neighbours that lie outside of the tree domain.
-    pub fn neighbors(&self) -> Vec<MortonKey> {
+    pub fn neighbors(&self) -> Vec<MortonKey<T>> {
         DIRECTIONS
             .iter()
             .map(|d| self.find_key_in_direction(d))
@@ -758,7 +812,7 @@ impl MortonKey {
     }
 
     /// Find all neighbors for to a given key, even if they lie outside of the tree domain.
-    pub fn all_neighbors(&self) -> Vec<Option<MortonKey>> {
+    pub fn all_neighbors(&self) -> Vec<Option<MortonKey<T>>> {
         DIRECTIONS
             .iter()
             .map(|d| self.find_key_in_direction(d))
@@ -766,7 +820,7 @@ impl MortonKey {
     }
 
     /// Check if two keys are adjacent with respect to each other when they are known to on the same tree level.
-    pub fn is_adjacent_same_level(&self, other: &MortonKey) -> bool {
+    pub fn is_adjacent_same_level(&self, other: &MortonKey<T>) -> bool {
         // Calculate distance between centres of each node
         let da = 1 << (DEEPEST_LEVEL - self.level());
         let db = 1 << (DEEPEST_LEVEL - other.level());
@@ -792,7 +846,7 @@ impl MortonKey {
     }
 
     /// Check if two keys are adjacent with respect to each other
-    pub fn is_adjacent(&self, other: &MortonKey) -> bool {
+    pub fn is_adjacent(&self, other: &MortonKey<T>) -> bool {
         let ancestors = self.ancestors();
         let other_ancestors = other.ancestors();
 
@@ -805,34 +859,8 @@ impl MortonKey {
     }
 }
 
-impl PartialEq for MortonKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.morton == other.morton
-    }
-}
-impl Eq for MortonKey {}
-
-impl Ord for MortonKey {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.morton.cmp(&other.morton)
-    }
-}
-
-impl PartialOrd for MortonKey {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.morton.cmp(&other.morton))
-    }
-}
-
-impl Hash for MortonKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.morton.hash(state);
-    }
-}
-
-impl<T: RlstScalar + Float + Default> TreeNode<T> for MortonKey {
-    type Nodes = MortonKeys;
-
+impl<T: RlstScalar + Float + Default> TreeNode<T> for MortonKey<T> {
+    type Nodes = MortonKeys<T>;
     type Domain = Domain<T>;
 
     fn children(&self) -> Self::Nodes {
@@ -911,7 +939,7 @@ pub fn surface_grid<T: RlstScalar + Float + Default>(expansion_order: usize) -> 
     surface
 }
 
-impl<T: RlstScalar<Real = T> + Float + Default> FmmTreeNode<T> for MortonKey {
+impl<T: RlstScalar<Real = T> + Float + Default> FmmTreeNode<T> for MortonKey<T> {
     fn convolution_grid(
         &self,
         expansion_order: usize,
@@ -1026,14 +1054,14 @@ use mpi::{
 };
 
 #[cfg(feature = "mpi")]
-unsafe impl Equivalence for MortonKey {
+unsafe impl<T> Equivalence for MortonKey<T> {
     type Out = UserDatatype;
     fn equivalent_datatype() -> Self::Out {
         UserDatatype::structured(
             &[1, 1],
             &[
-                offset_of!(MortonKey, anchor) as Address,
-                offset_of!(MortonKey, morton) as Address,
+                offset_of!(MortonKey<T>, anchor) as Address,
+                offset_of!(MortonKey<T>, morton) as Address,
             ],
             &[
                 UncommittedUserDatatype::contiguous(3, &u64::equivalent_datatype()).as_ref(),
@@ -1057,7 +1085,7 @@ mod test {
 
     /// Implementation of Algorithm 12 in [1]. to compare the ordering of two **Morton Keys**. If key
     /// `a` is less than key `b`, this function evaluates to true.
-    fn less_than(a: &MortonKey, b: &MortonKey) -> Option<bool> {
+    fn less_than<T: Default + Float + Debug>(a: &MortonKey<T>, b: &MortonKey<T>) -> Option<bool> {
         // If anchors match, the one at the coarser level has the lesser Morton id.
         let same_anchor = (a.anchor[0] == b.anchor[0])
             & (a.anchor[1] == b.anchor[1])
@@ -1204,8 +1232,8 @@ mod test {
         let a = [0, 0, 0];
         let b = [1, 1, 1];
 
-        let a = MortonKey::from_anchor(&a, DEEPEST_LEVEL);
-        let b = MortonKey::from_anchor(&b, DEEPEST_LEVEL);
+        let a = MortonKey::<f64>::from_anchor(&a, DEEPEST_LEVEL);
+        let b = MortonKey::<f64>::from_anchor(&b, DEEPEST_LEVEL);
         let mut sa = a.siblings();
         let mut sb = b.siblings();
         sa.sort();
@@ -1223,7 +1251,7 @@ mod test {
 
         let domain = Domain::from_local_points(points.data());
 
-        let mut keys: Vec<MortonKey> = Vec::new();
+        let mut keys: Vec<MortonKey<_>> = Vec::new();
 
         for i in 0..points.shape()[0] {
             let point = [points[[i, 0]], points[[i, 1]], points[[i, 2]]];
@@ -1232,7 +1260,7 @@ mod test {
         }
 
         // Add duplicates to keys, to test ordering in terms of equality
-        let mut cpy: Vec<MortonKey> = keys.to_vec();
+        let mut cpy = keys.to_vec();
         keys.append(&mut cpy);
 
         // Add duplicates to ensure equality is also sorted
@@ -1250,45 +1278,39 @@ mod test {
 
     #[test]
     fn test_find_children() {
-        let key = MortonKey {
-            morton: 0,
-            anchor: [0, 0, 0],
-        };
+        let key = MortonKey::<f64>::new(&[0, 0, 0], 0);
         let displacement = 1 << (DEEPEST_LEVEL - key.level() - 1);
 
-        let expected: Vec<MortonKey> = vec![
-            MortonKey {
-                anchor: [0, 0, 0],
-                morton: 1,
-            },
-            MortonKey {
-                anchor: [displacement, 0, 0],
-                morton: 0b100000000000000000000000000000000000000000000000000000000000001,
-            },
-            MortonKey {
-                anchor: [0, displacement, 0],
-                morton: 0b10000000000000000000000000000000000000000000000000000000000001,
-            },
-            MortonKey {
-                anchor: [0, 0, displacement],
-                morton: 0b1000000000000000000000000000000000000000000000000000000000001,
-            },
-            MortonKey {
-                anchor: [displacement, displacement, 0],
-                morton: 0b110000000000000000000000000000000000000000000000000000000000001,
-            },
-            MortonKey {
-                anchor: [displacement, 0, displacement],
-                morton: 0b101000000000000000000000000000000000000000000000000000000000001,
-            },
-            MortonKey {
-                anchor: [0, displacement, displacement],
-                morton: 0b11000000000000000000000000000000000000000000000000000000000001,
-            },
-            MortonKey {
-                anchor: [displacement, displacement, displacement],
-                morton: 0b111000000000000000000000000000000000000000000000000000000000001,
-            },
+        let expected: Vec<MortonKey<f64>> = vec![
+            MortonKey::new(&[0, 0, 0], 1),
+            MortonKey::new(
+                &[displacement, 0, 0],
+                0b100000000000000000000000000000000000000000000000000000000000001,
+            ),
+            MortonKey::new(
+                &[0, displacement, 0],
+                0b10000000000000000000000000000000000000000000000000000000000001,
+            ),
+            MortonKey::new(
+                &[0, 0, displacement],
+                0b1000000000000000000000000000000000000000000000000000000000001,
+            ),
+            MortonKey::new(
+                &[displacement, displacement, 0],
+                0b110000000000000000000000000000000000000000000000000000000000001,
+            ),
+            MortonKey::new(
+                &[displacement, 0, displacement],
+                0b101000000000000000000000000000000000000000000000000000000000001,
+            ),
+            MortonKey::new(
+                &[0, displacement, displacement],
+                0b11000000000000000000000000000000000000000000000000000000000001,
+            ),
+            MortonKey::new(
+                &[displacement, displacement, displacement],
+                0b111000000000000000000000000000000000000000000000000000000000001,
+            ),
         ];
 
         let children = key.children();
@@ -1308,7 +1330,7 @@ mod test {
 
         let key = MortonKey::from_point(&point, &domain, DEEPEST_LEVEL);
 
-        let mut ancestors: Vec<MortonKey> = key.ancestors().into_iter().collect();
+        let mut ancestors: Vec<MortonKey<_>> = key.ancestors().into_iter().collect();
         ancestors.sort();
 
         // Test that all ancestors found
@@ -1323,32 +1345,20 @@ mod test {
     #[test]
     pub fn test_finest_ancestor() {
         // Trivial case
-        let key: MortonKey = MortonKey {
-            anchor: [0, 0, 0],
-            morton: 0,
-        };
+        let key = MortonKey::<f64>::new(&[0, 0, 0], 0);
         let result = key.finest_ancestor(&key);
-        let expected: MortonKey = MortonKey {
-            anchor: [0, 0, 0],
-            morton: 0,
-        };
+        let expected = MortonKey::<f64>::new(&[0, 0, 0], 0);
         assert!(result == expected);
 
         // Standard case
         let displacement = 1 << (DEEPEST_LEVEL - key.level() - 1);
-        let a: MortonKey = MortonKey {
-            anchor: [0, 0, 0],
-            morton: 16,
-        };
-        let b: MortonKey = MortonKey {
-            anchor: [displacement, displacement, displacement],
-            morton: 0b111000000000000000000000000000000000000000000000000000000000001,
-        };
+        let a = MortonKey::<f64>::new(&[0, 0, 0], 16);
+        let b = MortonKey::new(
+            &[displacement, displacement, displacement],
+            0b111000000000000000000000000000000000000000000000000000000000001,
+        );
         let result = a.finest_ancestor(&b);
-        let expected: MortonKey = MortonKey {
-            anchor: [0, 0, 0],
-            morton: 0,
-        };
+        let expected = MortonKey::new(&[0, 0, 0], 0);
         assert!(result == expected);
     }
 
@@ -1401,7 +1411,7 @@ mod test {
                 [displacement, displacement, displacement],
             ];
 
-            let mut expected: Vec<MortonKey> = expected
+            let mut expected: Vec<MortonKey<_>> = expected
                 .iter()
                 .map(|n| {
                     [
@@ -1465,7 +1475,7 @@ mod test {
                 [displacement, displacement, displacement],
             ];
 
-            let mut expected: Vec<MortonKey> = expected
+            let mut expected: Vec<MortonKey<_>> = expected
                 .iter()
                 .map(|n| {
                     [
@@ -1474,11 +1484,12 @@ mod test {
                         (n[2] + (anchor[2] as i64)) as u64,
                     ]
                 })
-                .map(|anchor| MortonKey::from_anchor(&anchor, DEEPEST_LEVEL))
-                .map(|key| MortonKey {
-                    anchor: key.anchor,
-                    morton: ((key.morton >> LEVEL_DISPLACEMENT) << LEVEL_DISPLACEMENT)
-                        | parent.level(),
+                .map(|anchor| MortonKey::<f64>::from_anchor(&anchor, DEEPEST_LEVEL))
+                .map(|key| {
+                    let anchor = key.anchor;
+                    let morton =
+                        ((key.morton >> LEVEL_DISPLACEMENT) << LEVEL_DISPLACEMENT) | parent.level();
+                    MortonKey::new(&anchor, morton)
                 })
                 .collect();
             expected.sort();
@@ -1498,10 +1509,7 @@ mod test {
     #[test]
     pub fn test_morton_keys_iterator() {
         let n_points = 1000;
-        let domain = Domain {
-            origin: [-1.01, -1.01, -1.01],
-            side_length: [2.0, 2.0, 2.0],
-        };
+        let domain = Domain::new(&[-1.01, -1.01, -1.01], &[2.0, 2.0, 2.0]);
         let min = Some(-1.01);
         let max = Some(0.99);
 
@@ -1525,12 +1533,8 @@ mod test {
 
     #[test]
     fn test_linearize_keys() {
-        let key = MortonKey {
-            morton: 15,
-            anchor: [0, 0, 0],
-        };
-
-        let ancestors: Vec<MortonKey> = key.ancestors().into_iter().collect();
+        let key = MortonKey::<f64>::new(&[0, 0, 0], 15);
+        let ancestors = key.ancestors().into_iter().collect_vec();
         let linearized = linearize_keys(&ancestors);
 
         assert_eq!(linearized.len(), 1);
@@ -1612,10 +1616,7 @@ mod test {
 
     #[test]
     fn test_find_descendants() {
-        let key = MortonKey {
-            morton: 0,
-            anchor: [0, 0, 0],
-        };
+        let key = MortonKey::<f64>::new(&[0, 0, 0], 0);
 
         let descendants = key.descendants(1).unwrap();
         assert_eq!(descendants.len(), 8);
@@ -1628,23 +1629,17 @@ mod test {
 
     #[test]
     fn test_find_descendants_errors() {
-        let key = MortonKey {
-            morton: 0,
-            anchor: [0, 0, 0],
-        };
+        let key = MortonKey::<f64>::new(&[0, 0, 0], 0);
         assert!(key.descendants(17).is_err());
     }
 
     #[test]
     fn test_complete_region() {
-        let a: MortonKey = MortonKey {
-            anchor: [0, 0, 0],
-            morton: 16,
-        };
-        let b: MortonKey = MortonKey {
-            anchor: [65535, 65535, 65535],
-            morton: 0b111111111111111111111111111111111111111111111111000000000010000,
-        };
+        let a = MortonKey::<f64>::new(&[0, 0, 0], 16);
+        let b = MortonKey::<f64>::new(
+            &[LEVEL_SIZE - 1, LEVEL_SIZE - 1, LEVEL_SIZE - 1],
+            0b111111111111111111111111111111111111111111111111000000000010000,
+        );
 
         let region = complete_region(&a, &b);
 
@@ -1687,8 +1682,8 @@ mod test {
 
     #[test]
     pub fn test_balance() {
-        let a = MortonKey::from_anchor(&[0, 0, 0], DEEPEST_LEVEL);
-        let b = MortonKey::from_anchor(&[1, 1, 1], DEEPEST_LEVEL);
+        let a = MortonKey::<f64>::from_anchor(&[0, 0, 0], DEEPEST_LEVEL);
+        let b = MortonKey::<f64>::from_anchor(&[1, 1, 1], DEEPEST_LEVEL);
 
         let mut complete = complete_region(&a, &b);
         let start_val = vec![a];
@@ -1768,7 +1763,7 @@ mod test {
 
         // Test keys on different levels
         let anchor_a = [0, 0, 0];
-        let a = MortonKey::from_anchor(&anchor_a, DEEPEST_LEVEL - 1);
+        let a = MortonKey::<f64>::from_anchor(&anchor_a, DEEPEST_LEVEL - 1);
         let anchor_b = [2, 2, 2];
         let b = MortonKey::from_anchor(&anchor_b, DEEPEST_LEVEL);
         assert!(a.is_adjacent(&b));
@@ -1777,10 +1772,7 @@ mod test {
     #[test]
     fn test_encoding_is_always_absolute() {
         let point = [-0.099999, -0.099999, -0.099999];
-        let domain: Domain<f64> = Domain {
-            origin: [-0.1, -0.1, -0.1],
-            side_length: [1., 1., 1.],
-        };
+        let domain = Domain::<f64>::new(&[-0.1, -0.1, -0.1], &[1., 1., 1.]);
 
         let a = MortonKey::from_point(&point, &domain, 1);
         let b = MortonKey::from_point(&point, &domain, 16);
@@ -1791,10 +1783,7 @@ mod test {
     #[test]
     fn test_transfer_vector() {
         let point = [0.5, 0.5, 0.5];
-        let domain = Domain {
-            origin: [0., 0., 0.],
-            side_length: [1., 1., 1.],
-        };
+        let domain = Domain::<f64>::new(&[0., 0., 0.], &[1., 1., 1.]);
 
         // Test scale independence of transfer vectors
         let a = MortonKey::from_point(&point, &domain, 2);

--- a/kifmm/src/tree/morton.rs
+++ b/kifmm/src/tree/morton.rs
@@ -851,8 +851,7 @@ where
 
 impl<T> TreeNode<T> for MortonKey<T::Real>
 where
-    T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat,
+    T: RlstScalarFloat<Real = T>,
 {
     type Nodes = MortonKeys<T::Real>;
     type Domain = Domain<T::Real>;

--- a/kifmm/src/tree/morton.rs
+++ b/kifmm/src/tree/morton.rs
@@ -1276,8 +1276,8 @@ mod test {
 
     #[test]
     fn test_find_children() {
-        let key = MortonKey::<f64>::new(&[0, 0, 0], 0);
-        let displacement = 1 << (DEEPEST_LEVEL - key.level() - 1);
+        let root = MortonKey::<f64>::root();
+        let displacement = 1 << (DEEPEST_LEVEL - root.level() - 1);
 
         let expected: Vec<MortonKey<f64>> = vec![
             MortonKey::new(&[0, 0, 0], 1),
@@ -1311,7 +1311,7 @@ mod test {
             ),
         ];
 
-        let children = key.children();
+        let children = root.children();
 
         for child in &children {
             assert!(expected.contains(child));
@@ -1320,10 +1320,7 @@ mod test {
 
     #[test]
     fn test_ancestors() {
-        let domain: Domain<f64> = Domain {
-            origin: [0., 0., 0.],
-            side_length: [1., 1., 1.],
-        };
+        let domain = Domain::new(&[0., 0., 0.], &[1., 1., 1.]);
         let point = [0.5, 0.5, 0.5];
 
         let key = MortonKey::from_point(&point, &domain, DEEPEST_LEVEL);
@@ -1343,13 +1340,13 @@ mod test {
     #[test]
     pub fn test_finest_ancestor() {
         // Trivial case
-        let key = MortonKey::<f64>::new(&[0, 0, 0], 0);
-        let result = key.finest_ancestor(&key);
-        let expected = MortonKey::<f64>::new(&[0, 0, 0], 0);
+        let root = MortonKey::<f64>::root();
+        let result = root.finest_ancestor(&root);
+        let expected = root.clone();
         assert!(result == expected);
 
         // Standard case
-        let displacement = 1 << (DEEPEST_LEVEL - key.level() - 1);
+        let displacement = 1 << (DEEPEST_LEVEL - root.level() - 1);
         let a = MortonKey::<f64>::new(&[0, 0, 0], 16);
         let b = MortonKey::new(
             &[displacement, displacement, displacement],
@@ -1363,10 +1360,7 @@ mod test {
     #[test]
     pub fn test_neighbors() {
         let point = [0.5, 0.5, 0.5];
-        let domain: Domain<f64> = Domain {
-            side_length: [1., 1., 1.],
-            origin: [0., 0., 0.],
-        };
+        let domain = Domain::new(&[0., 0., 0.], &[1., 1., 1.]);
         let key = MortonKey::from_point(&point, &domain, DEEPEST_LEVEL);
 
         // Simple case, at the leaf level
@@ -1541,10 +1535,7 @@ mod test {
 
     #[test]
     fn test_point_to_anchor() {
-        let domain = Domain {
-            origin: [0., 0., 0.],
-            side_length: [1., 1., 1.],
-        };
+        let domain = Domain::new(&[0., 0., 0.], &[1., 1., 1.]);
 
         // Test points in the domain
         let point = [0.9999, 0.9999, 0.9999];
@@ -1556,10 +1547,7 @@ mod test {
             assert_eq!(a, &expected[i])
         }
 
-        let domain = Domain {
-            origin: [-0.7, -0.6, -0.5],
-            side_length: [1., 1., 1.],
-        };
+        let domain = Domain::new(&[-0.7, -0.6, -0.5], &[1., 1., 1.]);
 
         let point = [-0.499, -0.499, -0.499];
         let level = 1;
@@ -1573,10 +1561,7 @@ mod test {
 
     #[test]
     fn test_point_to_anchor_fails() {
-        let domain = Domain {
-            origin: [0., 0., 0.],
-            side_length: [1., 1., 1.],
-        };
+        let domain = Domain::new(&[0., 0., 0.], &[1., 1., 1.]);
 
         // Test a point not in the domain
         let point = [1.9, 0.9, 0.9];
@@ -1586,10 +1571,7 @@ mod test {
 
     #[test]
     fn test_point_to_anchor_fails_negative_domain() {
-        let domain = Domain {
-            origin: [-0.5, -0.5, -0.5],
-            side_length: [1., 1., 1.],
-        };
+        let domain = Domain::new(&[-0.5, -0.5, -0.5], &[1., 1., 1.]);
 
         // Test a point not in the domain
         let point = [-0.51, -0.5, -0.5];
@@ -1614,9 +1596,9 @@ mod test {
 
     #[test]
     fn test_find_descendants() {
-        let key = MortonKey::<f64>::new(&[0, 0, 0], 0);
+        let root = MortonKey::<f64>::root();
 
-        let descendants = key.descendants(1).unwrap();
+        let descendants = root.descendants(1).unwrap();
         assert_eq!(descendants.len(), 8);
 
         // Ensure this also works for other keys in hierarchy
@@ -1627,8 +1609,8 @@ mod test {
 
     #[test]
     fn test_find_descendants_errors() {
-        let key = MortonKey::<f64>::new(&[0, 0, 0], 0);
-        assert!(key.descendants(17).is_err());
+        let root = MortonKey::<f64>::root();
+        assert!(root.descendants(17).is_err());
     }
 
     #[test]
@@ -1730,10 +1712,7 @@ mod test {
     #[test]
     fn test_is_adjacent() {
         let point = [0.5, 0.5, 0.5];
-        let domain = Domain {
-            origin: [-0.1, -0.1, 0.1],
-            side_length: [1., 1., 1.],
-        };
+        let domain = Domain::new(&[-0.1, -0.1, -0.1], &[1., 1., 1.]);
 
         let key = MortonKey::from_point(&point, &domain, DEEPEST_LEVEL);
 
@@ -1810,10 +1789,7 @@ mod test {
     #[test]
     fn test_transfer_vector_errors() {
         let point = [0.5, 0.5, 0.5];
-        let domain = Domain {
-            origin: [0., 0., 0.],
-            side_length: [1., 1., 1.],
-        };
+        let domain = Domain::<f64>::new(&[0., 0., 0.], &[1., 1., 1.]);
         let key = MortonKey::from_point(&point, &domain, 1);
         let sibling = key.siblings()[0];
         assert!(key.find_transfer_vector(&sibling).is_err());
@@ -1822,10 +1798,7 @@ mod test {
     #[test]
     fn test_surface_grid() {
         let point = [0.5, 0.5, 0.5];
-        let domain = Domain {
-            origin: [0., 0., 0.],
-            side_length: [1., 1., 1.],
-        };
+        let domain = Domain::<f64>::new(&[0., 0., 0.], &[1., 1., 1.]);
         let key = MortonKey::from_point(&point, &domain, 0);
 
         let expansion_order = 2;

--- a/kifmm/src/tree/morton.rs
+++ b/kifmm/src/tree/morton.rs
@@ -65,9 +65,7 @@ fn linearize_keys<T: RlstScalarFloat>(keys: &[MortonKey<T>]) -> Vec<MortonKey<T>
 ///
 /// - `keys` - A slice of Morton Keys to enforce the 2:1 balance upon. The keys should represent a
 /// contiguous space without gaps.
-fn balance_keys<T: RlstScalarFloat>(
-    keys: &[MortonKey<T>],
-) -> HashSet<MortonKey<T>> {
+fn balance_keys<T: RlstScalarFloat>(keys: &[MortonKey<T>]) -> HashSet<MortonKey<T>> {
     let mut balanced: HashSet<MortonKey<_>> = keys.iter().cloned().collect();
     let deepest_level = keys.iter().map(|key| key.level()).max().unwrap();
 
@@ -368,7 +366,7 @@ impl<T: RlstScalarFloat> MortonKey<T> {
         Self {
             anchor: *anchor,
             morton,
-            scalar: PhantomData::<T>
+            scalar: PhantomData::<T>,
         }
     }
 
@@ -376,7 +374,7 @@ impl<T: RlstScalarFloat> MortonKey<T> {
     pub fn root() -> Self {
         Self {
             anchor: [0, 0, 0],
-            morton: 1,
+            morton: 0,
             ..Default::default()
         }
     }
@@ -494,9 +492,9 @@ impl<T: RlstScalarFloat> MortonKey<T> {
     /// # Arguments
     /// `domain` - The physical domain with which we calculate the diameter with respect to.
     pub fn diameter(&self, domain: &Domain<T>) -> [T; 3] {
-        domain
-            .side_length
-            .map(|x| RlstScalar::powf(T::from(0.5).unwrap(), T::from(self.level()).unwrap().re()) * x)
+        domain.side_length.map(|x| {
+            RlstScalar::powf(T::from(0.5).unwrap(), T::from(self.level()).unwrap().re()) * x
+        })
     }
 
     /// The physical centre of a box specified by this Morton Key, calculated with respect to

--- a/kifmm/src/tree/morton.rs
+++ b/kifmm/src/tree/morton.rs
@@ -1337,7 +1337,8 @@ mod test {
         // Trivial case
         let root = MortonKey::<f64>::root();
         let result = root.finest_ancestor(&root);
-        let expected = root.clone();
+        let expected = root;
+
         assert!(result == expected);
 
         // Standard case

--- a/kifmm/src/tree/morton.rs
+++ b/kifmm/src/tree/morton.rs
@@ -53,7 +53,8 @@ where
         let mut key_set: HashSet<MortonKey<_>> = keys.iter().cloned().collect();
 
         for level in (0..=depth).rev() {
-            let work_set: Vec<&MortonKey<_>> = keys.iter().filter(|&&k| k.level() == level).collect();
+            let work_set: Vec<&MortonKey<_>> =
+                keys.iter().filter(|&&k| k.level() == level).collect();
 
             for work_item in work_set.iter() {
                 let mut ancestors = work_item.ancestors();
@@ -122,10 +123,7 @@ where
     ///
     /// - `start` - The Morton Key defining the beginning of the region to complete.
     /// - `end` - The Morton Key marking the end of the region.
-    pub fn complete_region(
-        start: &MortonKey<T>,
-        end: &MortonKey<T>,
-    ) -> Vec<MortonKey<T>> {
+    pub fn complete_region(start: &MortonKey<T>, end: &MortonKey<T>) -> Vec<MortonKey<T>> {
         let mut start_ancestors: HashSet<MortonKey<_>> = start.ancestors();
         let mut end_ancestors: HashSet<MortonKey<_>> = end.ancestors();
 
@@ -138,7 +136,9 @@ where
             start.finest_ancestor(end).children().into_iter().collect();
 
         while let Some(current_item) = work_list.pop() {
-            if (current_item > *start) & (current_item < *end) & !end_ancestors.contains(&current_item)
+            if (current_item > *start)
+                & (current_item < *end)
+                & !end_ancestors.contains(&current_item)
             {
                 minimal_tree.push(current_item);
             } else if (start_ancestors.contains(&current_item))

--- a/kifmm/src/tree/multi_node.rs
+++ b/kifmm/src/tree/multi_node.rs
@@ -4,7 +4,7 @@ use crate::{
     tree::{
         constants::DEEPEST_LEVEL,
         types::{Domain, MortonKey, MortonKeys, MultiNodeTree, Point, Points, SingleNodeTree},
-    },
+    }, RlstScalarFloatMpi,
 };
 
 use crate::hyksort::hyksort;
@@ -23,7 +23,7 @@ use super::morton::complete_region;
 
 impl<T> MultiNodeTree<T>
 where
-    T: Float + Default + Equivalence + Debug + RlstScalar<Real = T>,
+    T: RlstScalarFloatMpi<Real = T>,
 {
     /// Constructor for uniform trees, distributed with MPI, node refined to a user defined depth.
     ///
@@ -631,7 +631,7 @@ fn global_indices(n_points: usize, comm: &UserCommunicator) -> Vec<usize> {
 
 impl<T> Tree for MultiNodeTree<T>
 where
-    T: Float + Default + RlstScalar<Real = T>,
+    T:  RlstScalarFloatMpi<Real = T>,
 {
     type Scalar = T;
     type Domain = Domain<T>;

--- a/kifmm/src/tree/multi_node.rs
+++ b/kifmm/src/tree/multi_node.rs
@@ -4,7 +4,8 @@ use crate::{
     tree::{
         constants::DEEPEST_LEVEL,
         types::{Domain, MortonKey, MortonKeys, MultiNodeTree, Point, Points, SingleNodeTree},
-    }, RlstScalarFloatMpi,
+    },
+    RlstScalarFloatMpi,
 };
 
 use crate::hyksort::hyksort;
@@ -631,7 +632,7 @@ fn global_indices(n_points: usize, comm: &UserCommunicator) -> Vec<usize> {
 
 impl<T> Tree for MultiNodeTree<T>
 where
-    T:  RlstScalarFloatMpi<Real = T>,
+    T: RlstScalarFloatMpi<Real = T>,
 {
     type Scalar = T;
     type Domain = Domain<T>;

--- a/kifmm/src/tree/multi_node.rs
+++ b/kifmm/src/tree/multi_node.rs
@@ -12,13 +12,10 @@ use crate::hyksort::hyksort;
 use itertools::Itertools;
 use mpi::{
     topology::UserCommunicator,
-    traits::{Communicator, CommunicatorCollectives, Destination, Equivalence, Source},
+    traits::{Communicator, CommunicatorCollectives, Destination, Source},
     Rank,
 };
-use num::traits::Float;
-use rlst::RlstScalar;
 use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
 
 use super::morton::complete_region;
 
@@ -106,7 +103,7 @@ where
         let max = leaves.iter().max().unwrap();
 
         // Assign leaves to points, disregard unmapped as they are included by definition in leaves buffer
-        let _unmapped = SingleNodeTree::assign_nodes_to_points(&leaves, &mut points);
+        let _unmapped = SingleNodeTree::<T>::assign_nodes_to_points(&leaves, &mut points);
 
         // Group coordinates by leaves
         let mut leaves_to_coordinates = HashMap::new();
@@ -294,7 +291,7 @@ where
         let max = leaves.iter().max().unwrap();
 
         // Assign leaves to points, disregard unmapped
-        let _unmapped = SingleNodeTree::assign_nodes_to_points(&leaves, &mut points);
+        let _unmapped = SingleNodeTree::<T>::assign_nodes_to_points(&leaves, &mut points);
 
         // Leaves are those that are mapped and their siblings if they exist in the processors range
         let leaves: HashSet<MortonKey<_>> = points

--- a/kifmm/src/tree/multi_node.rs
+++ b/kifmm/src/tree/multi_node.rs
@@ -19,7 +19,7 @@ use rlst::RlstScalar;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 
-use super::{constants::ROOT, morton::complete_region};
+use super::morton::complete_region;
 
 impl<T> MultiNodeTree<T>
 where
@@ -77,7 +77,7 @@ where
         hyksort(&mut points, hyksort_subcomm_size, comm)?;
 
         // Find unique leaves specified by points on each processor
-        let leaves: HashSet<MortonKey> = points.iter().map(|p| p.encoded_key).collect();
+        let leaves: HashSet<MortonKey<_>> = points.iter().map(|p| p.encoded_key).collect();
         let mut leaves = MortonKeys::from(leaves);
         leaves.complete();
 
@@ -125,14 +125,14 @@ where
         // Find all keys in tree
         let range = [world.rank() as u64, min.morton, max.morton];
 
-        let tmp: HashSet<MortonKey> = leaves
+        let tmp: HashSet<MortonKey<_>> = leaves
             .iter()
             .flat_map(|leaf| leaf.ancestors().into_iter())
             .collect();
 
         // This additional step is needed in distributed trees to ensure that siblings of ancestors
         // are contained on each processor
-        let tmp: HashSet<MortonKey> = tmp
+        let tmp: HashSet<MortonKey<_>> = tmp
             .iter()
             .flat_map(|key| {
                 if key.level() != 0 {
@@ -146,8 +146,8 @@ where
         let mut keys = MortonKeys::from(tmp);
 
         // Create sets for inclusion testing
-        let leaves_set: HashSet<MortonKey> = leaves.iter().cloned().collect();
-        let keys_set: HashSet<MortonKey> = keys.iter().cloned().collect();
+        let leaves_set: HashSet<MortonKey<_>> = leaves.iter().cloned().collect();
+        let keys_set: HashSet<MortonKey<_>> = keys.iter().cloned().collect();
 
         // Group by level to perform efficient lookup
         keys.sort_by_key(|a| a.level());
@@ -265,7 +265,7 @@ where
         hyksort(&mut points, hyksort_subcomm_size, comm)?;
 
         // Find unique leaves specified by points on each processor
-        let leaves: HashSet<MortonKey> = points.iter().map(|p| p.encoded_key).collect();
+        let leaves: HashSet<MortonKey<_>> = points.iter().map(|p| p.encoded_key).collect();
         let mut leaves = MortonKeys::from(leaves);
         leaves.complete();
 
@@ -296,7 +296,7 @@ where
         let _unmapped = SingleNodeTree::assign_nodes_to_points(&leaves, &mut points);
 
         // Leaves are those that are mapped and their siblings if they exist in the processors range
-        let leaves: HashSet<MortonKey> = points
+        let leaves: HashSet<MortonKey<_>> = points
             .iter()
             .map(|p| p.encoded_key)
             .flat_map(|k| k.siblings())
@@ -323,14 +323,14 @@ where
         // Find all keys in tree
         let range = [world.rank() as u64, min.morton, max.morton];
 
-        let tmp: HashSet<MortonKey> = leaves
+        let tmp: HashSet<MortonKey<_>> = leaves
             .iter()
             .flat_map(|leaf| leaf.ancestors().into_iter())
             .collect();
 
         // This additional step is needed in distributed trees to ensure that siblings of ancestors
         // are contained on each processor
-        let tmp: HashSet<MortonKey> = tmp
+        let tmp: HashSet<MortonKey<_>> = tmp
             .iter()
             .flat_map(|key| {
                 if key.level() != 0 {
@@ -344,8 +344,8 @@ where
         let mut keys = MortonKeys::from(tmp);
 
         // Create sets for inclusion testing
-        let leaves_set: HashSet<MortonKey> = leaves.iter().cloned().collect();
-        let keys_set: HashSet<MortonKey> = keys.iter().cloned().collect();
+        let leaves_set: HashSet<MortonKey<_>> = leaves.iter().cloned().collect();
+        let keys_set: HashSet<MortonKey<_>> = keys.iter().cloned().collect();
 
         // Group by level to perform efficient lookup of nodes
         keys.sort_by_key(|a| a.level());
@@ -485,14 +485,15 @@ where
     }
 
     fn complete_block_tree(
-        seeds: &mut MortonKeys,
+        seeds: &mut MortonKeys<T>,
         rank: i32,
         size: i32,
         world: &UserCommunicator,
-    ) -> MortonKeys {
+    ) -> MortonKeys<T> {
+        let root = MortonKey::root();
         // Define the tree's global domain with the finest first/last descendants
         if rank == 0 {
-            let ffc_root = ROOT.finest_first_child();
+            let ffc_root = root.finest_first_child();
             let min = seeds.iter().min().unwrap();
             let fa = ffc_root.finest_ancestor(min);
             let first_child = fa.children().into_iter().min().unwrap();
@@ -501,7 +502,7 @@ where
         }
 
         if rank == (size - 1) {
-            let flc_root = ROOT.finest_last_child();
+            let flc_root = root.finest_last_child();
             let max = seeds.iter().max().unwrap();
             let fa = flc_root.finest_ancestor(max);
             let last_child = fa.children().into_iter().max().unwrap();
@@ -534,7 +535,7 @@ where
             let a = seeds[i];
             let b = seeds[i + 1];
 
-            let mut tmp: MortonKeys = complete_region(&a, &b).into();
+            let mut tmp: MortonKeys<T> = complete_region(&a, &b).into();
             complete.keys.push(a);
             complete.keys.append(&mut tmp);
         }
@@ -551,7 +552,7 @@ where
     fn transfer_points_to_blocktree(
         world: &UserCommunicator,
         points: &[Point<T>],
-        seeds: &[MortonKey],
+        seeds: &[MortonKey<T>],
         &rank: &Rank,
         &size: &Rank,
     ) -> Points<T> {
@@ -634,10 +635,10 @@ where
 {
     type Scalar = T;
     type Domain = Domain<T>;
-    type Node = MortonKey;
-    type NodeSlice<'a> = &'a [MortonKey]
+    type Node = MortonKey<T>;
+    type NodeSlice<'a> = &'a [MortonKey<T>]
         where T: 'a;
-    type Nodes = MortonKeys;
+    type Nodes = MortonKeys<T>;
 
     fn n_coordinates(&self, leaf: &Self::Node) -> Option<usize> {
         self.coordinates(leaf).map(|coords| coords.len() / 3)

--- a/kifmm/src/tree/multi_node.rs
+++ b/kifmm/src/tree/multi_node.rs
@@ -17,7 +17,6 @@ use mpi::{
 };
 use std::collections::{HashMap, HashSet};
 
-use super::morton::complete_region;
 
 impl<T> MultiNodeTree<T>
 where
@@ -533,7 +532,7 @@ where
             let a = seeds[i];
             let b = seeds[i + 1];
 
-            let mut tmp: MortonKeys<T> = complete_region(&a, &b).into();
+            let mut tmp: MortonKeys<T> = MortonKeys::complete_region(&a, &b).into();
             complete.keys.push(a);
             complete.keys.append(&mut tmp);
         }

--- a/kifmm/src/tree/multi_node.rs
+++ b/kifmm/src/tree/multi_node.rs
@@ -17,7 +17,6 @@ use mpi::{
 };
 use std::collections::{HashMap, HashSet};
 
-
 impl<T> MultiNodeTree<T>
 where
     T: RlstScalarFloatMpi<Real = T>,

--- a/kifmm/src/tree/point.rs
+++ b/kifmm/src/tree/point.rs
@@ -1,23 +1,23 @@
 //! Implementation of traits for handling, and sorting, containers of point data.
 use crate::tree::types::Point;
-use rlst::RlstScalar;
+use crate::RlstScalarFloat;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 
 impl<T> PartialEq for Point<T>
 where
-    T: RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     fn eq(&self, other: &Self) -> bool {
         self.encoded_key == other.encoded_key
     }
 }
 
-impl<T> Eq for Point<T> where T: RlstScalar<Real = T> {}
+impl<T> Eq for Point<T> where T: RlstScalarFloat<Real = T> {}
 
 impl<T> Ord for Point<T>
 where
-    T: RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     fn cmp(&self, other: &Self) -> Ordering {
         self.encoded_key.cmp(&other.encoded_key)
@@ -26,7 +26,7 @@ where
 
 impl<T> PartialOrd for Point<T>
 where
-    T: RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         // less_than(&self.morton, &other.morton)
@@ -36,7 +36,7 @@ where
 
 impl<T> Hash for Point<T>
 where
-    T: RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.encoded_key.hash(state);
@@ -45,9 +45,9 @@ where
 
 #[cfg(feature = "mpi")]
 mod mpi_point {
-    use super::{Point, RlstScalar};
+    use super::Point;
 
-    use crate::tree::types::MortonKey;
+    use crate::{tree::types::MortonKey, RlstScalarFloat};
     use memoffset::offset_of;
     use mpi::{
         datatype::{Equivalence, UncommittedUserDatatype, UserDatatype},
@@ -57,7 +57,7 @@ mod mpi_point {
 
     unsafe impl<T> Equivalence for Point<T>
     where
-        T: RlstScalar<Real = T> + Float + Equivalence,
+        T: RlstScalarFloat<Real = T> + Float + Equivalence,
     {
         type Out = UserDatatype;
         fn equivalent_datatype() -> Self::Out {
@@ -119,10 +119,7 @@ mod test {
 
     #[test]
     pub fn test_ordering() {
-        let domain = Domain {
-            origin: [0., 0., 0.],
-            side_length: [1., 1., 1.],
-        };
+        let domain = Domain::<f64>::new(&[0., 0., 0.], &[1., 1., 1.]);
 
         let n_points = 1000;
         let coords = points_fixture(n_points, None, None, None);

--- a/kifmm/src/tree/point.rs
+++ b/kifmm/src/tree/point.rs
@@ -75,8 +75,8 @@ mod mpi_point {
                     UncommittedUserDatatype::structured(
                         &[1, 1],
                         &[
-                            offset_of!(MortonKey, anchor) as Address,
-                            offset_of!(MortonKey, morton) as Address,
+                            offset_of!(MortonKey<T>, anchor) as Address,
+                            offset_of!(MortonKey<T>, morton) as Address,
                         ],
                         &[
                             UncommittedUserDatatype::contiguous(3, &u64::equivalent_datatype())
@@ -89,8 +89,8 @@ mod mpi_point {
                     UncommittedUserDatatype::structured(
                         &[1, 1],
                         &[
-                            offset_of!(MortonKey, anchor) as Address,
-                            offset_of!(MortonKey, morton) as Address,
+                            offset_of!(MortonKey<T>, anchor) as Address,
+                            offset_of!(MortonKey<T>, morton) as Address,
                         ],
                         &[
                             UncommittedUserDatatype::contiguous(3, &u64::equivalent_datatype())

--- a/kifmm/src/tree/single_node.rs
+++ b/kifmm/src/tree/single_node.rs
@@ -814,11 +814,7 @@ mod test {
         // Generate points in a single octant of the domain
         let n_points = 10;
         let points = points_fixture::<f64>(n_points, Some(0.), Some(0.5), None);
-
-        let domain = Domain {
-            origin: [0.0, 0.0, 0.0],
-            side_length: [1.0, 1.0, 1.0],
-        };
+        let domain = Domain::new(&[0., 0., 0.], &[1., 1., 1.]);
 
         let mut tmp = Points::default();
         for i in 0..n_points {
@@ -832,6 +828,7 @@ mod test {
             })
         }
         let mut points = tmp;
+        points.sort();
         let keys = MortonKeys::from(root.children());
 
         SingleNodeTree::assign_nodes_to_points(&keys, &mut points);
@@ -853,9 +850,11 @@ mod test {
             )
             .0;
 
+        println!("HERE {:?}", leaves_to_points);
 
         // Test that a single octant contains all the points
         for (_, (l, r)) in leaves_to_points.iter() {
+            // println!("HERE {:?} {:?}", r, l);
             if (r - l) > 0 {
                 assert!((r - l) == n_points);
             }

--- a/kifmm/src/tree/single_node.rs
+++ b/kifmm/src/tree/single_node.rs
@@ -637,7 +637,7 @@ where
 impl<T> Tree for SingleNodeTree<T>
 where
     T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat
+    <T as RlstScalar>::Real: RlstScalarFloat,
 {
     type Scalar = T;
     type Domain = Domain<T::Real>;

--- a/kifmm/src/tree/single_node.rs
+++ b/kifmm/src/tree/single_node.rs
@@ -5,16 +5,16 @@ use crate::tree::{
     morton::encode_anchor,
     types::{Domain, MortonKey, MortonKeys, Point, Points, SingleNodeTree},
 };
+use crate::RlstScalarFloat;
 use itertools::Itertools;
-use num::Float;
-use rlst::RlstScalar;
+
 use std::collections::{HashMap, HashSet};
 
 use super::morton::complete_region;
 
 impl<T> SingleNodeTree<T>
 where
-    T: Float + Default + RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     /// Constructor for uniform trees on a single node refined to a user defined depth.
     ///
@@ -635,7 +635,7 @@ where
 
 impl<T> Tree for SingleNodeTree<T>
 where
-    T: Float + Default + RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     type Scalar = T;
     type Domain = Domain<T>;
@@ -739,7 +739,6 @@ where
 
 #[cfg(test)]
 mod test {
-    use std::fmt::Debug;
 
     use super::*;
     use crate::tree::helpers::{points_fixture, points_fixture_col};
@@ -798,7 +797,7 @@ mod test {
         assert_eq!(unique_leaves.len(), expected);
     }
 
-    pub fn test_no_overlaps_helper<T: Clone + Float + Debug + Default>(nodes: &[MortonKey<T>]) {
+    pub fn test_no_overlaps_helper<T: RlstScalarFloat>(nodes: &[MortonKey<T>]) {
         let key_set: HashSet<MortonKey<_>> = nodes.iter().cloned().collect();
 
         for node in key_set.iter() {
@@ -853,6 +852,7 @@ mod test {
                 },
             )
             .0;
+
 
         // Test that a single octant contains all the points
         for (_, (l, r)) in leaves_to_points.iter() {

--- a/kifmm/src/tree/single_node.rs
+++ b/kifmm/src/tree/single_node.rs
@@ -11,7 +11,6 @@ use rlst::RlstScalar;
 
 use std::collections::{HashMap, HashSet};
 
-use super::morton::complete_region;
 
 impl<T> SingleNodeTree<T>
 where
@@ -515,7 +514,7 @@ where
         for i in 0..(seeds.iter().len() - 1) {
             let a = seeds[i];
             let b = seeds[i + 1];
-            let mut tmp = complete_region(&a, &b);
+            let mut tmp = MortonKeys::complete_region(&a, &b);
             block_tree.keys.push(a);
             block_tree.keys.append(&mut tmp);
         }

--- a/kifmm/src/tree/single_node.rs
+++ b/kifmm/src/tree/single_node.rs
@@ -11,7 +11,6 @@ use rlst::RlstScalar;
 
 use std::collections::{HashMap, HashSet};
 
-
 impl<T> SingleNodeTree<T>
 where
     T: RlstScalarFloat<Real = T>,

--- a/kifmm/src/tree/types.rs
+++ b/kifmm/src/tree/types.rs
@@ -5,7 +5,10 @@ use mpi::topology::UserCommunicator;
 
 use num::traits::Float;
 use rlst::RlstScalar;
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    marker::PhantomData,
+};
 
 /// Represents a three-dimensional box characterized by its origin and side-length along the Cartesian axes.
 ///
@@ -46,18 +49,20 @@ where
 ///   spatial indexing and operations.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
-pub struct MortonKey {
+pub struct MortonKey<T> {
     /// The anchor is the index coordinate of the key, with respect to the origin of the Domain.
     pub anchor: [u64; 3],
     /// The Morton encoded anchor.
     pub morton: u64,
+    /// Scalar type of coordinate data associated with the key
+    pub scalar: PhantomData<T>,
 }
 
 /// A collection that stores and allows iteration over a sequence of `MortonKey` values.
 #[derive(Clone, Debug, Default)]
-pub struct MortonKeys {
+pub struct MortonKeys<T> {
     /// A vector of Morton_keys
-    pub keys: Vec<MortonKey>,
+    pub keys: Vec<MortonKey<T>>,
 
     /// index for implementing the Iterator trait.
     pub index: usize,
@@ -133,28 +138,28 @@ where
     pub global_indices: Vec<usize>,
 
     /// The leaves that span the tree.
-    pub leaves: MortonKeys,
+    pub leaves: MortonKeys<T>,
 
     /// All nodes in tree.
-    pub keys: MortonKeys,
+    pub keys: MortonKeys<T>,
 
     /// Associate leaves with point indices.
-    pub leaves_to_coordinates: HashMap<MortonKey, (usize, usize)>,
+    pub leaves_to_coordinates: HashMap<MortonKey<T>, (usize, usize)>,
 
     /// Associate levels with key indices.
     pub levels_to_keys: HashMap<u64, (usize, usize)>,
 
     /// Map between a key and its index
-    pub key_to_index: HashMap<MortonKey, usize>,
+    pub key_to_index: HashMap<MortonKey<T>, usize>,
 
     /// Map between a leaf and its index
-    pub leaf_to_index: HashMap<MortonKey, usize>,
+    pub leaf_to_index: HashMap<MortonKey<T>, usize>,
 
     /// All leaves, returned as a set.
-    pub leaves_set: HashSet<MortonKey>,
+    pub leaves_set: HashSet<MortonKey<T>>,
 
     /// All keys, returned as a set.
-    pub keys_set: HashSet<MortonKey>,
+    pub keys_set: HashSet<MortonKey<T>>,
 }
 
 /// Represents a 3D point within an octree structure, enriched with Morton encoding information.
@@ -190,10 +195,10 @@ where
     pub global_index: usize,
 
     /// Key at finest level of encoding.
-    pub base_key: MortonKey,
+    pub base_key: MortonKey<T>,
 
     /// Key at a given level of encoding, strictly an ancestor of 'base_key'.
-    pub encoded_key: MortonKey,
+    pub encoded_key: MortonKey<T>,
 }
 
 /// A collection of `Point` instances, each representing a 3D point within an octree structure.
@@ -258,26 +263,26 @@ where
     pub global_indices: Vec<usize>,
 
     /// The leaves that span the tree, and associated Point data.
-    pub leaves: MortonKeys,
+    pub leaves: MortonKeys<T>,
 
     /// All nodes in tree, and associated Node data.
-    pub keys: MortonKeys,
+    pub keys: MortonKeys<T>,
 
     /// Associate leaves with coordinate indices.
-    pub leaves_to_coordinates: HashMap<MortonKey, (usize, usize)>,
+    pub leaves_to_coordinates: HashMap<MortonKey<T>, (usize, usize)>,
 
     /// Associate levels with key indices.
     pub levels_to_keys: HashMap<u64, (usize, usize)>,
 
     /// Map between a key and its index
-    pub key_to_index: HashMap<MortonKey, usize>,
+    pub key_to_index: HashMap<MortonKey<T>, usize>,
 
     /// Map between a leaf and its index
-    pub leaf_to_index: HashMap<MortonKey, usize>,
+    pub leaf_to_index: HashMap<MortonKey<T>, usize>,
 
     /// All leaves, returned as a set.
-    pub leaves_set: HashSet<MortonKey>,
+    pub leaves_set: HashSet<MortonKey<T>>,
 
     /// All keys, returned as a set.
-    pub keys_set: HashSet<MortonKey>,
+    pub keys_set: HashSet<MortonKey<T>>,
 }

--- a/kifmm/src/tree/types.rs
+++ b/kifmm/src/tree/types.rs
@@ -2,13 +2,16 @@
 
 #[cfg(feature = "mpi")]
 use mpi::topology::UserCommunicator;
+#[cfg(feature = "mpi")]
+use crate::RlstScalarFloatMpi;
 
-use num::traits::Float;
 use rlst::RlstScalar;
 use std::{
     collections::{HashMap, HashSet},
     marker::PhantomData,
 };
+
+use crate::RlstScalarFloat;
 
 /// Represents a three-dimensional box characterized by its origin and side-length along the Cartesian axes.
 ///
@@ -22,7 +25,7 @@ use std::{
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Domain<T>
 where
-    T: Float + Default,
+    T: RlstScalarFloat,
 {
     /// The lower left corner of the domain, minimum of x, y, z values.
     pub origin: [T; 3],
@@ -49,7 +52,9 @@ where
 ///   spatial indexing and operations.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
-pub struct MortonKey<T> {
+pub struct MortonKey<T>
+
+{
     /// The anchor is the index coordinate of the key, with respect to the origin of the Domain.
     pub anchor: [u64; 3],
     /// The Morton encoded anchor.
@@ -117,7 +122,7 @@ pub struct MortonKeys<T> {
 #[cfg(feature = "mpi")]
 pub struct MultiNodeTree<T>
 where
-    T: Default + Float + RlstScalar<Real = T>,
+    T: RlstScalarFloatMpi<Real = T>,
 {
     /// Global communicator for this Tree
     pub world: UserCommunicator,
@@ -248,7 +253,7 @@ pub type Points<T> = Vec<Point<T>>;
 #[derive(Default)]
 pub struct SingleNodeTree<T>
 where
-    T: Float + Default + RlstScalar<Real = T>,
+    T: RlstScalarFloat<Real = T>,
 {
     /// Depth of a tree.
     pub depth: u64,

--- a/kifmm/src/tree/types.rs
+++ b/kifmm/src/tree/types.rs
@@ -1,9 +1,9 @@
 //! Data structures to create distributed octrees with MPI.
 
 #[cfg(feature = "mpi")]
-use mpi::topology::UserCommunicator;
-#[cfg(feature = "mpi")]
 use crate::RlstScalarFloatMpi;
+#[cfg(feature = "mpi")]
+use mpi::topology::UserCommunicator;
 
 use rlst::RlstScalar;
 use std::{
@@ -52,9 +52,7 @@ where
 ///   spatial indexing and operations.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
-pub struct MortonKey<T>
-
-{
+pub struct MortonKey<T> {
     /// The anchor is the index coordinate of the key, with respect to the origin of the Domain.
     pub anchor: [u64; 3],
     /// The Morton encoded anchor.

--- a/kifmm/src/tree/types.rs
+++ b/kifmm/src/tree/types.rs
@@ -4,7 +4,6 @@
 use crate::RlstScalarFloatMpi;
 #[cfg(feature = "mpi")]
 use mpi::topology::UserCommunicator;
-use rlst::RlstScalar;
 
 use std::{
     collections::{HashMap, HashSet},
@@ -28,10 +27,10 @@ where
     T: RlstScalarFloat<Real = T>,
 {
     /// The lower left corner of the domain, minimum of x, y, z values.
-    pub origin: [T::Real; 3],
+    pub origin: [T; 3],
 
     /// The extent of the point distribution along the x, y, z axes respectively.
-    pub side_length: [T::Real; 3],
+    pub side_length: [T; 3],
 }
 
 /// Represents a Morton key associated with a node within an octree structure.
@@ -61,7 +60,7 @@ where
     /// The Morton encoded anchor.
     pub morton: u64,
     /// Scalar type of coordinate data associated with the key
-    pub scalar: PhantomData<T::Real>,
+    pub scalar: PhantomData<T>,
 }
 
 /// A collection that stores and allows iteration over a sequence of `MortonKey` values.
@@ -126,8 +125,7 @@ where
 #[cfg(feature = "mpi")]
 pub struct MultiNodeTree<T>
 where
-    T: RlstScalarFloatMpi,
-    <T as RlstScalar>::Real: RlstScalarFloat,
+    T: RlstScalarFloatMpi<Real = T>,
 {
     /// Global communicator for this Tree
     pub world: UserCommunicator,
@@ -139,37 +137,37 @@ where
     pub depth: u64,
 
     /// Domain spanned by the points.
-    pub domain: Domain<T::Real>,
+    pub domain: Domain<T>,
 
     /// All points coordinates in row major format, such that [x1, y1, z1, ..., xn, yn, zn]
-    pub coordinates: Vec<T::Real>,
+    pub coordinates: Vec<T>,
 
     /// All global indices
     pub global_indices: Vec<usize>,
 
     /// The leaves that span the tree.
-    pub leaves: MortonKeys<T::Real>,
+    pub leaves: MortonKeys<T>,
 
     /// All nodes in tree.
-    pub keys: MortonKeys<T::Real>,
+    pub keys: MortonKeys<T>,
 
     /// Associate leaves with point indices.
-    pub leaves_to_coordinates: HashMap<MortonKey<T::Real>, (usize, usize)>,
+    pub leaves_to_coordinates: HashMap<MortonKey<T>, (usize, usize)>,
 
     /// Associate levels with key indices.
     pub levels_to_keys: HashMap<u64, (usize, usize)>,
 
     /// Map between a key and its index
-    pub key_to_index: HashMap<MortonKey<T::Real>, usize>,
+    pub key_to_index: HashMap<MortonKey<T>, usize>,
 
     /// Map between a leaf and its index
-    pub leaf_to_index: HashMap<MortonKey<T::Real>, usize>,
+    pub leaf_to_index: HashMap<MortonKey<T>, usize>,
 
     /// All leaves, returned as a set.
-    pub leaves_set: HashSet<MortonKey<T::Real>>,
+    pub leaves_set: HashSet<MortonKey<T>>,
 
     /// All keys, returned as a set.
-    pub keys_set: HashSet<MortonKey<T::Real>>,
+    pub keys_set: HashSet<MortonKey<T>>,
 }
 
 /// Represents a 3D point within an octree structure, enriched with Morton encoding information.
@@ -258,42 +256,41 @@ pub type Points<T> = Vec<Point<T>>;
 #[derive(Default)]
 pub struct SingleNodeTree<T>
 where
-    T: RlstScalarFloat,
-    <T as RlstScalar>::Real: RlstScalarFloat,
+    T: RlstScalarFloat<Real = T>,
 {
     /// Depth of a tree.
     pub depth: u64,
 
     /// Domain spanned by the points.
-    pub domain: Domain<T::Real>,
+    pub domain: Domain<T>,
 
     /// All points coordinates in row major format, such that [x1, y1, z1, ..., xn, yn, zn]
-    pub coordinates: Vec<T::Real>,
+    pub coordinates: Vec<T>,
 
     /// All global indices
     pub global_indices: Vec<usize>,
 
     /// The leaves that span the tree, and associated Point data.
-    pub leaves: MortonKeys<T::Real>,
+    pub leaves: MortonKeys<T>,
 
     /// All nodes in tree, and associated Node data.
-    pub keys: MortonKeys<T::Real>,
+    pub keys: MortonKeys<T>,
 
     /// Associate leaves with coordinate indices.
-    pub leaves_to_coordinates: HashMap<MortonKey<T::Real>, (usize, usize)>,
+    pub leaves_to_coordinates: HashMap<MortonKey<T>, (usize, usize)>,
 
     /// Associate levels with key indices.
     pub levels_to_keys: HashMap<u64, (usize, usize)>,
 
     /// Map between a key and its index
-    pub key_to_index: HashMap<MortonKey<T::Real>, usize>,
+    pub key_to_index: HashMap<MortonKey<T>, usize>,
 
     /// Map between a leaf and its index
-    pub leaf_to_index: HashMap<MortonKey<T::Real>, usize>,
+    pub leaf_to_index: HashMap<MortonKey<T>, usize>,
 
     /// All leaves, returned as a set.
-    pub leaves_set: HashSet<MortonKey<T::Real>>,
+    pub leaves_set: HashSet<MortonKey<T>>,
 
     /// All keys, returned as a set.
-    pub keys_set: HashSet<MortonKey<T::Real>>,
+    pub keys_set: HashSet<MortonKey<T>>,
 }


### PR DESCRIPTION
Codebase was fast and loose about exactly what types functionality is generic over, making it hard to add the Helmholtz FMM implementation, where potentials are complex.

To make this clearer, this PR:
* Adds a super trait for float/complexfloat/rlstscalar values, this allows individual traits/impls to specify whether they're working on real or complex, or both, data.
* Adds a phantom type to Morton keys, corresponding to the coordinate data it's associated with
* General cleanup, such as cleaning up constructors, and ensuring that they're being used
