### PR TITLE
CLN: Error handling for FMM results

### DIFF
--- a/kifmm/benches/single_node.rs
+++ b/kifmm/benches/single_node.rs
@@ -66,11 +66,11 @@ fn laplace_potentials_f32(c: &mut Criterion) {
         .measurement_time(Duration::from_secs(15));
 
     group.bench_function(format!("M2L=FFT, N={nsources}"), |b| {
-        b.iter(|| fmm_fft.evaluate())
+        b.iter(|| fmm_fft.evaluate().unwrap())
     });
 
     group.bench_function(format!("M2L=BLAS, N={nsources}"), |b| {
-        b.iter(|| fmm_blas.evaluate())
+        b.iter(|| fmm_blas.evaluate().unwrap())
     });
 }
 
@@ -130,12 +130,12 @@ fn helmholtz_potentials_f32(c: &mut Criterion) {
 
     group.bench_function(
         format!("M2L=FFT, N={nsources}, wavenumber={wavenumber}"),
-        |b| b.iter(|| fmm_fft.evaluate()),
+        |b| b.iter(|| fmm_fft.evaluate().unwrap()),
     );
 
     group.bench_function(
         format!("M2L=BLAS, N={nsources}, wavenumber={wavenumber}"),
-        |b| b.iter(|| fmm_blas.evaluate()),
+        |b| b.iter(|| fmm_blas.evaluate().unwrap()),
     );
 }
 
@@ -195,12 +195,12 @@ fn helmholtz_potentials_gradients_f32(c: &mut Criterion) {
 
     group.bench_function(
         format!("M2L=FFT, N={nsources}, wavenumber={wavenumber}"),
-        |b| b.iter(|| fmm_fft.evaluate()),
+        |b| b.iter(|| fmm_fft.evaluate().unwrap()),
     );
 
     group.bench_function(
         format!("M2L=BLAS, N={nsources}, wavenumber={wavenumber}"),
-        |b| b.iter(|| fmm_blas.evaluate()),
+        |b| b.iter(|| fmm_blas.evaluate().unwrap()),
     );
 }
 
@@ -257,11 +257,11 @@ fn laplace_potentials_gradients_f32(c: &mut Criterion) {
         .measurement_time(Duration::from_secs(20));
 
     group.bench_function(format!("M2L=FFT, N={nsources}"), |b| {
-        b.iter(|| fmm_fft.evaluate())
+        b.iter(|| fmm_fft.evaluate().unwrap())
     });
 
     group.bench_function(format!("M2L=BLAS, N={nsources}"), |b| {
-        b.iter(|| fmm_blas.evaluate())
+        b.iter(|| fmm_blas.evaluate().unwrap())
     });
 }
 

--- a/kifmm/examples/single_node_helmholtz.rs
+++ b/kifmm/examples/single_node_helmholtz.rs
@@ -44,7 +44,7 @@ fn main() {
             .unwrap()
             .build()
             .unwrap();
-        fmm_fft.evaluate();
+        fmm_fft.evaluate().unwrap();
     }
 
     // BLAS based M2L
@@ -78,7 +78,7 @@ fn main() {
             .build()
             .unwrap();
 
-        fmm_vec.evaluate();
+        fmm_vec.evaluate().unwrap();
 
         // Matrix of charges
         let nvecs = 5;
@@ -106,6 +106,6 @@ fn main() {
             .unwrap()
             .build()
             .unwrap();
-        fmm_mat.evaluate();
+        fmm_mat.evaluate().unwrap();
     }
 }

--- a/kifmm/examples/single_node_laplace.rs
+++ b/kifmm/examples/single_node_laplace.rs
@@ -39,7 +39,7 @@ fn main() {
             .unwrap()
             .build()
             .unwrap();
-        fmm_fft.evaluate();
+        fmm_fft.evaluate().unwrap();
     }
 
     // BLAS based M2L
@@ -69,7 +69,7 @@ fn main() {
             .build()
             .unwrap();
 
-        fmm_vec.evaluate();
+        fmm_vec.evaluate().unwrap();
 
         // Matrix of charges
         let nvecs = 5;
@@ -93,6 +93,6 @@ fn main() {
             .unwrap()
             .build()
             .unwrap();
-        fmm_mat.evaluate();
+        fmm_mat.evaluate().unwrap();
     }
 }

--- a/kifmm/src/traits.rs
+++ b/kifmm/src/traits.rs
@@ -4,3 +4,4 @@ pub mod field;
 pub mod fmm;
 pub mod general;
 pub mod tree;
+pub mod types;

--- a/kifmm/src/traits/fmm.rs
+++ b/kifmm/src/traits/fmm.rs
@@ -3,18 +3,18 @@ use crate::{fmm::types::Charges, traits::tree::FmmTree};
 use green_kernels::{traits::Kernel, types::EvalType};
 use rlst::RlstScalar;
 
-use super::tree::Tree;
+use super::{tree::Tree, types::FmmError};
 
 /// Interface for source field translations.
 pub trait SourceTranslation {
     /// Particle to multipole translations, applied at leaf level over all source boxes.
-    fn p2m(&self);
+    fn p2m(&self) -> Result<(), FmmError>;
 
     /// Multipole to multipole translations, applied during upward pass. Defined over each level of a tree.
     ///
     /// # Arguments
     /// * `level` - The child level at which this translation is being applied.
-    fn m2m(&self, level: u64);
+    fn m2m(&self, level: u64) -> Result<(), FmmError>;
 }
 
 /// Interface for target field translations.
@@ -23,20 +23,20 @@ pub trait TargetTranslation {
     ///
     /// # Arguments
     /// * `level` - The child level at which this translation is being applied.
-    fn l2l(&self, level: u64);
+    fn l2l(&self, level: u64) -> Result<(), FmmError>;
 
     /// Multipole to particle translations, applies to leaf boxes when a source box is within
     /// the near field of a target box, but is small enough that a multipole expansion converges
     /// at the target box. Defined over all leaf target boxes.
-    fn m2p(&self);
+    fn m2p(&self) -> Result<(), FmmError>;
 
     /// Local to particle translations, applies the local expansion accumulated at each leaf box to the
     /// target particles it contains. Defined over all leaf target boxes.
-    fn l2p(&self);
+    fn l2p(&self) -> Result<(), FmmError>;
 
     /// Near field particle to particle (direct) potential contributions to particles in a given leaf box's
     /// near field where the `p2l` and `m2p` do not apply. Defined over all leaf target boxes.
-    fn p2p(&self);
+    fn p2p(&self) -> Result<(), FmmError>;
 }
 
 /// Interface for the source to target (multipole to local / M2L) field translations.
@@ -45,7 +45,7 @@ pub trait SourceToTargetTranslation {
     ///
     /// # Arguments
     /// * `level` - The level of the tree at which this translation is being applied.
-    fn m2l(&self, level: u64);
+    fn m2l(&self, level: u64) -> Result<(), FmmError>;
 
     /// Particle to local translations, applies to leaf boxes when a source box is within
     /// the far field of a target box, but is too large for the multipole expansion to converge
@@ -53,7 +53,7 @@ pub trait SourceToTargetTranslation {
     ///
     /// # Arguments
     /// * `level` - The level of the tree at which this translation is being applied.
-    fn p2l(&self, level: u64);
+    fn p2l(&self, level: u64) -> Result<(), FmmError>;
 }
 
 /// Interface for a Kernel-Independent Fast Multipole Method (FMM).
@@ -110,7 +110,7 @@ where
     fn dim(&self) -> usize;
 
     /// Evaluate the potentials, or potential gradients, for this FMM
-    fn evaluate(&self);
+    fn evaluate(&self) -> Result<(), FmmError>;
 
     /// Clear the data buffers and add new charge data for re-evaluation.
     ///

--- a/kifmm/src/traits/types.rs
+++ b/kifmm/src/traits/types.rs
@@ -1,0 +1,35 @@
+//! Utility types for trait definitions.
+use std::fmt;
+
+/// Type to handle FMM related errors
+#[derive(Debug)]
+pub enum FmmError {
+    /// Failure to run some business logic
+    Failed(String),
+
+    /// Unimplemented section
+    Unimplemented(String),
+
+    /// I/O failure
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for FmmError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FmmError::Failed(e) => write!(f, "Failed: {}", e),
+            FmmError::Unimplemented(e) => write!(f, "Unimplemented: {}", e),
+            FmmError::Io(e) => write!(f, "I/O error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for FmmError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            FmmError::Io(e) => Some(e),
+            FmmError::Failed(_e) => None,
+            FmmError::Unimplemented(_e) => None,
+        }
+    }
+}


### PR DESCRIPTION
Closes #40 

* Wraps FMM results in Error types.
* Removes raw panics for cleaner failures.
