### PR TITLE
Rename benchmark groups

### DIFF
--- a/kifmm/benches/helmholtz_mat_f32.rs
+++ b/kifmm/benches/helmholtz_mat_f32.rs
@@ -65,7 +65,7 @@ fn helmholtz_potentials_f32(c: &mut Criterion) {
         .build()
         .unwrap();
 
-    let mut group = c.benchmark_group("Helmholtz Potentials f32");
+    let mut group = c.benchmark_group("Helmholtz Potentials mat f32");
     group
         .sample_size(10)
         .measurement_time(Duration::from_secs(200));

--- a/kifmm/benches/laplace_mat_f32.rs
+++ b/kifmm/benches/laplace_mat_f32.rs
@@ -62,7 +62,7 @@ fn laplace_potentials_f32(c: &mut Criterion) {
         .build()
         .unwrap();
 
-    let mut group = c.benchmark_group("Laplace Potentials f32");
+    let mut group = c.benchmark_group("Laplace Potentials mat f32");
     group
         .sample_size(10)
         .measurement_time(Duration::from_secs(100));


### PR DESCRIPTION
The scheduled benchmark running is failing due to two files using the same benchmark group names.

I've added "mat" to these names to stop this failure. A better renaming likely exists: Any ideas @skailasa?